### PR TITLE
Partial support of ST7701s

### DIFF
--- a/Arduino_Display.h
+++ b/Arduino_Display.h
@@ -20,6 +20,7 @@
 #include "Arduino_SSD1283A.h"        // Hardware-specific library for SSD1283A
 #include "Arduino_SSD1331.h"         // Hardware-specific library for SSD1331
 #include "Arduino_SSD1351.h"         // Hardware-specific library for SSD1351
+#include "Arduino_ST7701.h"          // Hardware-specific library for ST7701
 #include "Arduino_ST7735.h"          // Hardware-specific library for ST7735
 #include "Arduino_ST7789.h"          // Hardware-specific library for ST7789
 #include "Arduino_ST7796.h"          // Hardware-specific library for ST7796

--- a/Arduino_GFX_Library.h
+++ b/Arduino_GFX_Library.h
@@ -27,6 +27,7 @@
 #include "Arduino_SSD1283A.h"        // Hardware-specific library for SSD1283A
 #include "Arduino_SSD1331.h"         // Hardware-specific library for SSD1331
 #include "Arduino_SSD1351.h"         // Hardware-specific library for SSD1351
+#include "Arduino_ST7701.h"          // Hardware-specific library for ST7701
 #include "Arduino_ST7735.h"          // Hardware-specific library for ST7735
 #include "Arduino_ST7789.h"          // Hardware-specific library for ST7789
 #include "Arduino_ST7796.h"          // Hardware-specific library for ST7796

--- a/Arduino_ST7701.cpp
+++ b/Arduino_ST7701.cpp
@@ -1,0 +1,186 @@
+#include "Arduino_ST7701.h"
+
+#define DISPLAY_CMD(cmd, params...)                   \
+{                                                     \
+    const uint8_t d[] = {params};                     \
+    display_cmd(cmd, sizeof(d) / sizeof(uint8_t), d); \
+}
+
+Arduino_ST7701::Arduino_ST7701(
+    Arduino_DataBus *bus, int8_t rst, uint8_t r,
+    bool ips, int16_t w, int16_t h,
+    uint8_t col_offset1, uint8_t row_offset1, uint8_t col_offset2, uint8_t row_offset2)
+    : Arduino_TFT(bus, rst, r, ips, w, h, col_offset1, row_offset1, col_offset2, row_offset2)
+{
+}
+
+void Arduino_ST7701::begin(int speed)
+{
+#if defined(ESP8266) || defined(ESP32)
+  if (speed == 0)
+  {
+    speed = 40000000;
+  }
+#endif
+  Arduino_TFT::begin(speed);
+}
+
+// Companion code to the above tables.  Reads and issues
+// a series of LCD commands stored in PROGMEM byte array.
+void Arduino_ST7701::tftInit()
+{
+  Serial.println("Init Display ST7701"); 
+
+  // Software Reset
+  _bus->sendCommand(ST7701_SWRESET);
+  delay(ST7701_RST_DELAY);
+
+  // Sleep mode Off
+  _bus->sendCommand(ST7701_SLPOUT);
+  delay(ST7701_SLPOUT_DELAY);
+
+  // Command2 BK0
+  DISPLAY_CMD(DSI_CMD2BKX_SEL, 0x77, 0x01, 0x00, 0x00, ST7701_CMD2BK0SEL);
+  DISPLAY_CMD(ST7701_BK0_LNESET, 0x3B, 0x00);
+  DISPLAY_CMD(ST7701_BK0_PORCTRL, 0x0D, 0x02);  // vbp, vfp
+  DISPLAY_CMD(ST7701_BK0_INVSEL, 0x21, 0x08);
+  //DISPLAY_CMD(0xCD, 0x21, 0x08); // ???
+  DISPLAY_CMD(ST7701_BK0_PVGAMCTRL, 0x00, 0x11, 0x18, 0x0E, 0x11, 0x06, 0x07, 0x08, 0x07, 0x22, 0x04, 0x12, 0x0F, 0xAA, 0x31, 0x18);
+  DISPLAY_CMD(ST7701_BK0_NVGAMCTRL, 0x00, 0x11, 0x19, 0x0E, 0x12, 0x07, 0x18, 0x08, 0x08, 0x22, 0x04, 0x11, 0x11, 0xA9, 0x32, 0x18);
+
+  // Command2 BK1
+  DISPLAY_CMD(DSI_CMD2BKX_SEL, 0x77, 0x01, 0x00, 0x00, ST7701_CMD2BK1SEL);
+  DISPLAY_CMD(ST7701_BK1_VRHS, 0x60);
+  DISPLAY_CMD(ST7701_BK1_VCOM, 0x30);
+  DISPLAY_CMD(ST7701_BK1_VGHSS, 0x87);
+  DISPLAY_CMD(ST7701_BK1_TESTCMD, 0x80);
+  DISPLAY_CMD(ST7701_BK1_VGLS, 0x49);
+  DISPLAY_CMD(ST7701_BK1_PWCTLR1, 0x85);
+  DISPLAY_CMD(ST7701_BK1_PWCTLR2, 0x21);
+  DISPLAY_CMD(ST7701_BK1_SPD1, 0x78);
+  DISPLAY_CMD(ST7701_BK1_SPD2, 0x78);
+  DISPLAY_CMD(0xD0, 0x88);
+
+  DISPLAY_CMD(0xE0, 0x00, 0x1B, 0x02);
+  DISPLAY_CMD(0xE1, 0x08, 0xA0, 0x00, 0x00, 0x07, 0xA0, 0x00, 0x00, 0x00, 0x44, 0x44);
+  DISPLAY_CMD(0xE2, 0x11, 0x11, 0x44, 0x44, 0xED, 0xA0, 0x00, 0x00, 0xEC, 0xA0, 0x00, 0x00);
+  DISPLAY_CMD(0xE3, 0x00, 0x00, 0x11, 0x11);
+  DISPLAY_CMD(0xE4, 0x44, 0x44);
+  DISPLAY_CMD(0xE5, 0x0A, 0xE9, 0xD8, 0xA0, 0x0C, 0xEB, 0xD8, 0xA0, 0x0E, 0xED, 0xD8, 0xA0, 0x10, 0xEF, 0xD8, 0xA0);
+  DISPLAY_CMD(0xE6, 0x00, 0x00, 0x11, 0x11);
+  DISPLAY_CMD(0xE7, 0x44, 0x44);
+  DISPLAY_CMD(0xE8, 0x09, 0xE8, 0xD8, 0xA0, 0x0B, 0xEA, 0xD8, 0xA0, 0x0D, 0xEC, 0xD8, 0xA0, 0x0F, 0xEE, 0xD8, 0xA0);
+  DISPLAY_CMD(0xEB, 0x02, 0x00, 0xE4, 0xE4, 0x88, 0x00, 0x40);
+  DISPLAY_CMD(0xEC, 0x3C, 0x00);
+  DISPLAY_CMD(0xED, 0xAB, 0x89, 0x76, 0x54, 0x02, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x20, 0x45, 0x67, 0x98, 0xBA);
+  DISPLAY_CMD(0xEF, 0x10, 0x0D, 0x04, 0x08, 0x3F, 0x1F);
+
+  // Command2 BK2
+  DISPLAY_CMD(DSI_CMD2BKX_SEL, 0x77, 0x01, 0x00, 0x00, ST7701_CMD2BKxSEL_NONE);
+
+  // set pixel format
+  DISPLAY_CMD(ST7701_COLMOD, 0x66);
+
+  // Normal Mode On
+  _bus->sendCommand(ST7701_NORON);
+
+  // Display On
+  _bus->sendCommand(ST7701_DISPON);
+
+  if (_ips)
+  {
+    _bus->sendCommand(ST7701_INVON);
+  }
+
+  // All Pixels on
+  //_bus->sendCommand(ST7701_ALLPON);
+
+  Serial.println("End Display ST7701 initialization");
+}
+ // TODO: it does not work
+void Arduino_ST7701::writeAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+{
+  Serial.print("writeAddrWindow: ");
+  if ((x != _currentX) || (w != _currentW))
+  {
+    _bus->writeC8D16D16(ST7701_CASET, x + _xStart, x + w - 1 + _xStart);
+
+    _currentX = x;
+    _currentW = w;
+  }
+  if ((y != _currentY) || (h != _currentH))
+  {
+    _bus->writeC8D16D16(ST7701_RASET, y + _yStart, y + h - 1 + _yStart);
+
+    _currentY = y;
+    _currentH = h;
+  }
+
+  _bus->writeCommand(ST7701_RAMWR); // write to RAM
+}
+
+/**************************************************************************/
+/*!
+    @brief   Set origin of (0,0) and orientation of TFT display
+    @param   m  The index for rotation, from 0-3 inclusive
+*/
+/**************************************************************************/
+void Arduino_ST7701::setRotation(uint8_t r)
+{
+  Arduino_TFT::setRotation(r);
+  switch (_rotation)
+  {
+  case 0:
+    // r = ST7701_MADCTL_MX | ST7701_MADCTL_MY | ST7701_MADCTL_BGR | ST7701_MADCTL_MH;
+    r = ST7701_MADCTL_MY | ST7701_MADCTL_BGR;
+    break;
+
+  case 1:
+    // r = ST7701_MADCTL_MY | ST7701_MADCTL_MV | ST7701_MADCTL_BGR | ST7701_MADCTL_MH;
+    r = ST7701_MADCTL_MX | ST7701_MADCTL_MY | ST7701_MADCTL_MV | ST7701_MADCTL_BGR;
+    break;
+
+  case 2:
+    r = ST7701_MADCTL_MX | ST7701_MADCTL_ML | ST7701_MADCTL_BGR | ST7701_MADCTL_MH;
+    r = ST7701_MADCTL_MX | ST7701_MADCTL_BGR;
+    break;
+
+  case 3:
+    // r = ST7701_MADCTL_MX | ST7701_MADCTL_MV | ST7701_MADCTL_BGR | ST7701_MADCTL_MH;
+    r = ST7701_MADCTL_MV | ST7701_MADCTL_BGR;
+    break;
+  }
+
+  _bus->beginWrite();
+  _bus->writeCommand(ST7701_MADCTL);
+  _bus->write(r);
+  _bus->endWrite();
+}
+
+void Arduino_ST7701::invertDisplay(bool i)
+{
+  _bus->sendCommand(_ips ? (i ? ST7701_INVOFF : ST7701_INVON) : (i ? ST7701_INVON : ST7701_INVOFF));
+}
+
+void Arduino_ST7701::displayOn(void)
+{
+  _bus->sendCommand(ST7701_SLPOUT);
+  delay(ST7701_SLPOUT_DELAY);
+}
+
+void Arduino_ST7701::displayOff(void)
+{
+  _bus->sendCommand(ST7701_SLPIN);
+  delay(ST7701_SLPIN_DELAY);
+}
+
+void Arduino_ST7701::display_cmd(const uint8_t cmd, const uint8_t count, const uint8_t *data) {
+  _bus->beginWrite();
+  _bus->writeCommand(cmd);
+  if (count > 0) {
+    for (uint8_t i = 0; i < count; i++) {
+      _bus->write(data[i]);
+    }
+  }
+  _bus->endWrite();
+}

--- a/Arduino_ST7701.h
+++ b/Arduino_ST7701.h
@@ -1,0 +1,102 @@
+#ifndef _ARDUINO_ST7701_H_
+#define _ARDUINO_ST7701_H_
+
+#include "Arduino.h"
+#include "Print.h"
+#include "Arduino_GFX.h"
+#include "Arduino_TFT.h"
+
+#define ST7701_TFTWIDTH 480
+#define ST7701_TFTHEIGHT 480
+
+#define ST7701_RST_DELAY 120    ///< delay ms wait for reset finish
+#define ST7701_SLPIN_DELAY 120  ///< delay ms wait for sleep in finish
+#define ST7701_SLPOUT_DELAY 120 ///< delay ms wait for sleep out finish
+
+#define ST7701_NOP       0x00
+#define ST7701_SWRESET   0x01  ///< Software reset
+#define ST7701_RDDPM     0x0A  ///< Read Display Power Mode
+#define ST7701_RDDCOLMOD 0x0C  ///< Read Display Pixel Format
+#define ST7701_RDDIM     0x0D  ///< Read Display Image Mode
+#define ST7701_RDDSM     0x0E  ///< Read Display Signal Mode
+#define ST7701_RDDSDR    0x0F  ///< Read Display Self-diagnostic result
+#define ST7701_SLPIN     0x10  ///< Sleep in
+#define ST7701_SLPOUT    0x11  ///< Sleep out
+#define ST7701_PTLON     0x12  ///< Partial mode on
+#define ST7701_NORON     0x13  ///< Normal display mode on
+#define ST7701_INVOFF    0x20  ///< Display inversion off (normal)
+#define ST7701_INVON     0x21  ///< Display inversion on
+#define ST7701_ALLPON    0x23  ///< All Pixels On
+#define ST7701_DISPOFF   0x28  ///< Display off
+#define ST7701_DISPON    0x29  ///< Display on
+#define ST7701_TEON      0x35  ///< Tearing effect line on
+#define ST7701_MADCTL    0x36  ///< Display data access control
+#define ST7701_COLMOD    0x3A  ///< Interface Pixel Format
+#define ST7701_WRDISBV   0x51  ///< Write display brightness
+#define ST7701_SDIR      0xC7  ///< Source direction control
+#define ST7701_RDID1     0xDA  ///< Read ID1
+#define ST7701_RDID2     0xDB  ///< Read ID2
+#define ST7701_RDID3     0xDC  ///< Read ID3
+
+#define ST7701_CND2BKxSEL 0xFF  ///< Command2 BKx Selection
+
+#define ST7701_BK0_PVGAMCTRL 0xB0  ///< Positive Voltage Gamma Control
+#define ST7701_BK0_NVGAMCTRL 0xB1  ///< Negative Voltage Gamma Control
+#define ST7701_BK0_LNESET    0xC0  ///< Display Line setting
+#define ST7701_BK0_PORCTRL   0xC1  ///< Porch control
+#define ST7701_BK0_INVSEL    0xC2  ///< Inversion selection & Frame Rate Control
+#define ST7701_BK0_RGBCTRL   0xC3  ///< RGB control
+#define ST7701_BK0_PARCTRL   0xC5  ///< Partial mode Control
+#define ST7701_BK0_SDIR      0xC7  ///< Source direction control
+
+#define ST7701_BK1_VRHS    0xB0  ///< Vop amplitude setting
+#define ST7701_BK1_VCOM    0xB1  ///< VCOM amplitude setting
+#define ST7701_BK1_VGHSS   0xB2  ///< VGH Voltage setting
+#define ST7701_BK1_TESTCMD 0xB3  ///< TEST Command Setting
+#define ST7701_BK1_VGLS    0xB5  ///< VGL Voltage setting
+#define ST7701_BK1_PWCTLR1 0xB7  ///< Power Control 1
+#define ST7701_BK1_PWCTLR2 0xB8  ///< Power Control 2
+#define ST7701_BK1_SPD1    0xC1  ///< Source pre_drive timing set1
+#define ST7701_BK1_SPD2    0xC2  ///< Source EQ2 Setting
+
+#define DSI_CMD2BKX_SEL			   0xFF  ///< Command2 BKx selection command
+#define ST7701_CMD2BKxSEL_NONE 0x00  ///< Command2 BKx Selection None
+#define ST7701_CMD2BK0SEL      0x10  ///< Command2 BK0 Selection
+#define ST7701_CMD2BK1SEL      0x11  ///< Command2 BK1 Selection
+
+#define ST7701_CASET 0x2A
+#define ST7701_RASET 0x2B
+#define ST7701_RAMWR 0x2C
+#define ST7701_RAMRD 0x2E
+
+#define ST7701_MADCTL_MY 0x80
+#define ST7701_MADCTL_MX 0x40
+#define ST7701_MADCTL_MV 0x20
+#define ST7701_MADCTL_ML 0x10
+#define ST7701_MADCTL_RGB 0x00
+#define ST7701_MADCTL_BGR 0x08
+#define ST7701_MADCTL_MH 0x04
+
+class Arduino_ST7701 : public Arduino_TFT
+{
+public:
+  Arduino_ST7701(
+      Arduino_DataBus *bus, int8_t rst = -1, uint8_t r = 0,
+      bool ips = false, int16_t w = ST7701_TFTWIDTH, int16_t h = ST7701_TFTHEIGHT,
+      uint8_t col_offset1 = 0, uint8_t row_offset1 = 0, uint8_t col_offset2 = 0, uint8_t row_offset2 = 0);
+
+  virtual void begin(int speed = 0);
+  virtual void writeAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  virtual void setRotation(uint8_t r);
+  virtual void invertDisplay(bool);
+  virtual void displayOn();
+  virtual void displayOff();
+
+protected:
+  virtual void tftInit();
+  virtual void display_cmd(const uint8_t cmd, const uint8_t count, const uint8_t *data);
+
+private:
+};
+
+#endif


### PR DESCRIPTION
Added initialization of ST7701. It was tested over 9-bit SPI from ESP32. The screen successfully initializes and works turning on all pixels over SPI command.

I didn't find possibility to work with specific pixels over SPI. So `writeAddrWindow` method does not works. Could you please suggest me how to do it?