### PR TITLE
Arduino_Canvas_Indexed Optimization

### DIFF
--- a/src/canvas/Arduino_Canvas_Indexed.cpp
+++ b/src/canvas/Arduino_Canvas_Indexed.cpp
@@ -16,7 +16,6 @@ Arduino_Canvas_Indexed::Arduino_Canvas_Indexed(int16_t w, int16_t h, Arduino_G *
     }
     _current_mask_level = mask_level;
     _color_mask = mask_level_list[_current_mask_level];
-    _color_to_index_map.
 }
 
 void Arduino_Canvas_Indexed::begin(int32_t speed)
@@ -172,7 +171,7 @@ void Arduino_Canvas_Indexed::raise_mask_level()
         for (uint8_t old_color = 0; old_color < old_indexed_size; old_color++)
         {
             uint16_t old_color_indexing = _color_index[old_color];
-            
+
             _color_to_index_map.erase(old_color_indexing);      //remove the color with old mask
             new_color = get_color_index(old_color_indexing);    //insert color with new mask
             

--- a/src/canvas/Arduino_Canvas_Indexed.h
+++ b/src/canvas/Arduino_Canvas_Indexed.h
@@ -5,7 +5,8 @@
 #ifndef _Arduino_CANVAS_INDEXED_H_
 #define _Arduino_CANVAS_INDEXED_H_
 
-#include "../Arduino_GFX.h"
+#include "Arduino_GFX.h"
+#include <unordered_map>
 
 #define COLOR_IDX_SIZE 256
 
@@ -29,6 +30,7 @@ protected:
   Arduino_G *_output;
   int16_t _output_x, _output_y;
   uint16_t _color_index[COLOR_IDX_SIZE];
+  std::unordered_map<uint16_t, uint8_t> _color_to_index_map(COLOR_IDX_SIZE);
   uint8_t _indexed_size = 0;
   uint8_t _current_mask_level;
   uint16_t _color_mask;

--- a/src/canvas/Arduino_Canvas_Indexed.h
+++ b/src/canvas/Arduino_Canvas_Indexed.h
@@ -5,7 +5,7 @@
 #ifndef _Arduino_CANVAS_INDEXED_H_
 #define _Arduino_CANVAS_INDEXED_H_
 
-#include "Arduino_GFX.h"
+#include "../Arduino_GFX.h"
 #include <unordered_map>
 
 #define COLOR_IDX_SIZE 256


### PR DESCRIPTION
This pull request have two optimizations:

 - Lowers time complexity of `Arduino_Canvas_Indexed ::get_color_index()` from O(n) to O(1), by using a hashmap (`std::unordered_map`) to keep track of color to index, instead of searching the whole `_color_index[]` array.
 now it should have  a nice speedup.

 - Lowers time complexity of `Arduino_Canvas_Indexed::raise_mask_level()` from O(n*m) to O(m) - where **n** is `COLOR_IDX_SIZE` and **m** is `_framebuffer` size- .
 now it should have a significant speedup
 
 
#### note: if you wish to, you can use only one of them, with some minor changes in the code.