### PR TITLE
Added support for 8-bit parallel bus on STM32

### DIFF
--- a/src/Arduino_GFX_Library.h
+++ b/src/Arduino_GFX_Library.h
@@ -22,6 +22,7 @@
 #include "databus/Arduino_RPiPicoPAR16.h"
 #include "databus/Arduino_RPiPicoSPI.h"
 #include "databus/Arduino_RTLPAR8.h"
+#include "databus/Arduino_STM32PAR8.h"
 #include "databus/Arduino_SWSPI.h"
 
 #include "Arduino_GFX.h" // Core graphics library

--- a/src/databus/Arduino_STM32PAR8.cpp
+++ b/src/databus/Arduino_STM32PAR8.cpp
@@ -1,0 +1,251 @@
+#ifdef ARDUINO_ARCH_STM32
+
+#include "Arduino_STM32PAR8.h"
+
+Arduino_STM32PAR8::Arduino_STM32PAR8(int8_t dc, int8_t cs, int8_t wr, int8_t rd, GPIO_TypeDef *port)
+    : _dc(dc), _cs(cs), _wr(wr), _rd(rd), _port(port)
+{
+}
+
+void Arduino_STM32PAR8::begin(int32_t speed, int8_t dataMode)
+{
+  UNUSED(speed);
+  UNUSED(dataMode);
+  set_GPIO_Port_Clock(STM_PORT(_port)); // Enable data port
+  pinMode(_dc, OUTPUT);
+  digitalWrite(_dc, HIGH); // Data mode
+  _dcPORT = digitalPinToPort(_dc);
+  _dcPinMaskSet = digitalPinToBitMask(_dc);
+
+  if (_cs >= 0)
+  {
+    pinMode(_cs, OUTPUT);
+    digitalWrite(_cs, HIGH); // Disable chip select
+    _csPinMaskSet = digitalPinToBitMask(_cs);
+    _csPORT = digitalPinToPort(_cs);
+  }
+  else
+  {
+    _csPinMaskSet = 0;
+  }
+  
+  pinMode(_wr, OUTPUT);
+  digitalWrite(_wr, HIGH); // Set write strobe high (inactive)
+  _wrPort = (PORTreg_t)portOutputRegister(digitalPinToPort(_wr));
+  _wrPORT = digitalPinToPort(_wr);
+  _wrPinMaskSet = digitalPinToBitMask(_wr);
+  _wrPinMaskClr = ~_wrPinMaskSet;
+
+  if (_rd >= 0)
+  {
+    pinMode(_rd, OUTPUT);
+    digitalWrite(_rd, HIGH); // Disable RD
+    _rdPinMaskSet = digitalPinToBitMask(_rd);
+  }
+  else
+  {
+    _rdPinMaskSet = 0;
+  }
+
+  *(portModeRegister(_port)) = 0x33333333;  // Set data port to output at max speed
+  _port->BSRR = 0xFF << 16; //Clear data port
+}
+
+void Arduino_STM32PAR8::beginWrite()
+{
+  DC_HIGH();
+  CS_LOW();
+}
+
+void Arduino_STM32PAR8::endWrite()
+{
+  CS_HIGH();
+}
+
+void Arduino_STM32PAR8::writeCommand(uint8_t c)
+{
+  DC_LOW();
+
+  WRITE(c);
+
+  DC_HIGH();
+}
+
+void Arduino_STM32PAR8::writeCommand16(uint16_t c)
+{
+  DC_LOW();
+
+  _data16.value = c;
+  WRITE(_data16.msb);
+  WRITE(_data16.lsb);
+
+  DC_HIGH();
+}
+
+void Arduino_STM32PAR8::write(uint8_t d)
+{
+  WRITE(d);
+}
+
+void Arduino_STM32PAR8::write16(uint16_t d)
+{
+  _data16.value = d;
+  WRITE(_data16.msb);
+  WRITE(_data16.lsb);
+}
+
+void Arduino_STM32PAR8::writeRepeat(uint16_t p, uint32_t len)
+{
+  uint8_t wrMaskBase = *_wrPort & _wrPinMaskClr;
+  uint8_t wrMaskSet = wrMaskBase | _wrPinMaskSet;
+  uint32_t wrMASKCLR = _wrPinMaskSet << 16;
+  _data16.value = p;
+  if (_data16.msb == _data16.lsb)
+  {
+    _port->BSRR = 0xFF << 16;
+    _port->BSRR = (_data16.msb) & 0xFF;
+    while (len--)
+    {
+      *_wrPort = wrMaskBase; // For some reason in this case it's faster then BSRR
+      *_wrPort = wrMaskSet;
+      *_wrPort = wrMaskBase;
+      *_wrPort = wrMaskSet;
+    }
+  }
+  else
+  {
+    while (len--)
+    {
+      _port->BSRR = 0xFF << 16;
+      _port->BSRR = (_data16.msb);
+      *_wrPort = wrMaskBase;
+      *_wrPort = wrMaskSet;
+
+      _port->BSRR = 0xFF << 16;
+      _port->BSRR = (_data16.lsb);
+      *_wrPort = wrMaskBase;
+      *_wrPort = wrMaskSet;
+    }
+  }
+}
+
+void Arduino_STM32PAR8::writePixels(uint16_t *data, uint32_t len)
+{
+  while (len--)
+  {
+    _data16.value = *data++;
+    WRITE(_data16.msb);
+    WRITE(_data16.lsb);
+  }
+}
+
+void Arduino_STM32PAR8::writeC8D8(uint8_t c, uint8_t d)
+{
+  DC_LOW();
+
+  WRITE(c);
+
+  DC_HIGH();
+
+  WRITE(d);
+}
+
+void Arduino_STM32PAR8::writeC8D16(uint8_t c, uint16_t d)
+{
+  DC_LOW();
+
+  WRITE(c);
+
+  DC_HIGH();
+
+  _data16.value = d;
+  WRITE(_data16.msb);
+  WRITE(_data16.lsb);
+}
+
+void Arduino_STM32PAR8::writeC8D16D16(uint8_t c, uint16_t d1, uint16_t d2)
+{
+  DC_LOW();
+
+  WRITE(c);
+
+  DC_HIGH();
+
+  _data16.value = d1;
+  WRITE(_data16.msb);
+  WRITE(_data16.lsb);
+
+  _data16.value = d2;
+  WRITE(_data16.msb);
+  WRITE(_data16.lsb);
+}
+
+void Arduino_STM32PAR8::writeBytes(uint8_t *data, uint32_t len)
+{
+  while (len--)
+  {
+    WRITE(*data++);
+  }
+}
+
+void Arduino_STM32PAR8::writePattern(uint8_t *data, uint8_t len, uint32_t repeat)
+{
+  while (repeat--)
+  {
+    writeBytes(data, len);
+  }
+}
+
+void Arduino_STM32PAR8::writeIndexedPixels(uint8_t *data, uint16_t *idx, uint32_t len)
+{
+  while (len--)
+  {
+    _data16.value = idx[*data++];
+    WRITE(_data16.msb);
+    WRITE(_data16.lsb);
+  }
+}
+
+void Arduino_STM32PAR8::writeIndexedPixelsDouble(uint8_t *data, uint16_t *idx, uint32_t len)
+{
+  while (len--)
+  {
+    _data16.value = idx[*data++];
+    WRITE(_data16.msb);
+    WRITE(_data16.lsb);
+    WRITE(_data16.msb);
+    WRITE(_data16.lsb);
+  }
+}
+
+INLINE void Arduino_STM32PAR8::WRITE(uint8_t d)
+{
+  _port->BSRR = 0xFF << 16;
+  _port->BSRR = (d)&0xFF;
+  _wrPORT->BSRR = _wrPinMaskSet << 16;  //Set WR LOW
+  _wrPORT->BSRR = _wrPinMaskSet;  //Set WR HIGH
+}
+
+/******** low level bit twiddling **********/
+
+INLINE void Arduino_STM32PAR8::DC_HIGH(void)
+{
+  _dcPORT->BSRR = _dcPinMaskSet;
+}
+
+INLINE void Arduino_STM32PAR8::DC_LOW(void)
+{
+  _dcPORT->BSRR = _dcPinMaskSet << 16;
+}
+
+INLINE void Arduino_STM32PAR8::CS_HIGH(void)
+{
+  _csPORT->BSRR = _csPinMaskSet;
+}
+
+INLINE void Arduino_STM32PAR8::CS_LOW(void)
+{
+  _csPORT->BSRR = _csPinMaskSet << 16;
+}
+
+#endif // #ifdef ARDUINO_ARCH_STM32

--- a/src/databus/Arduino_STM32PAR8.h
+++ b/src/databus/Arduino_STM32PAR8.h
@@ -1,0 +1,57 @@
+#ifdef ARDUINO_ARCH_STM32
+
+#ifndef _ARDUINO_STM32PAR8_H_
+#define _ARDUINO_STM32PAR8_H_
+
+#include "Arduino_DataBus.h"
+
+class Arduino_STM32PAR8 : public Arduino_DataBus
+{
+public:
+  Arduino_STM32PAR8(int8_t dc, int8_t cs, int8_t wr, int8_t rd, GPIO_TypeDef* port); // Constructor
+
+  void begin(int32_t speed = 0, int8_t dataMode = 0) override;
+  void beginWrite() override;
+  void endWrite() override;
+  void writeCommand(uint8_t) override;
+  void writeCommand16(uint16_t) override;
+  void write(uint8_t) override;
+  void write16(uint16_t) override;
+  void writeRepeat(uint16_t p, uint32_t len) override;
+  void writePixels(uint16_t *data, uint32_t len) override;
+
+  void writeC8D8(uint8_t c, uint8_t d) override;
+  void writeC8D16(uint8_t c, uint16_t d) override;
+  void writeC8D16D16(uint8_t c, uint16_t d1, uint16_t d2) override;
+  void writeBytes(uint8_t *data, uint32_t len) override;
+  void writePattern(uint8_t *data, uint8_t len, uint32_t repeat) override;
+
+  void writeIndexedPixels(uint8_t *data, uint16_t *idx, uint32_t len) override;
+  void writeIndexedPixelsDouble(uint8_t *data, uint16_t *idx, uint32_t len) override;
+
+protected:
+private:
+  INLINE void WRITE(uint8_t d);
+  INLINE void DC_HIGH(void);
+  INLINE void DC_LOW(void);
+  INLINE void CS_HIGH(void);
+  INLINE void CS_LOW(void);
+
+  int8_t _dc, _cs, _wr, _rd;
+  GPIO_TypeDef* _port;
+  GPIO_TypeDef* _dcPORT; 
+  GPIO_TypeDef* _csPORT;
+  GPIO_TypeDef* _wrPORT;
+  GPIO_TypeDef* _rdPORT;
+
+  ARDUINOGFX_PORT_t _dcPinMaskSet;   ///< Bitmask for data/command SET (OR)
+  ARDUINOGFX_PORT_t _csPinMaskSet;   ///< Bitmask for data/command SET (OR)
+  PORTreg_t _wrPort;                 ///< PORT register for data/command
+  ARDUINOGFX_PORT_t _wrPinMaskSet;   ///< Bitmask for data/command SET (OR)
+  ARDUINOGFX_PORT_t _wrPinMaskClr;   ///< Bitmask for data/command CLEAR (AND)
+  ARDUINOGFX_PORT_t _rdPinMaskSet;   ///< Bitmask for data/command SET (OR)
+};
+
+#endif // _ARDUINO_STM32PAR8_H_
+
+#endif // #ifdef ARDUINO_ARCH_STM32


### PR DESCRIPTION
I've added support for 8-bit parallel interface on STM32. I based it on existing AVRPAR8 databus, but used some specific to STM32 functions to achieve greater speed. Writing to ``portOutputRegister`` is slower than writing to ``BSRR`` but if you want consistency with your AVR code, then it can be done that way too.
I've tested with bluepill board but as far as I can see the code is model agnostic and *should* work on any STM32 using official arduino core.
Overall I achieved sufficient speed, this is a result of PDQgraphicstest benchmark with my ILI9331 display, screen size is set to 240x320:
```
Screen fill	134667
Text	42630
Pixels	1394096
Lines	1462224
Horiz/Vert Lines	14910
Rectangles (filled)	333704
Rectangles (outline)	11578
Triangles (filled)	165004
Triangles (outline)	80814
Circles (filled)	104140
Circles (outline)	129691
Arcs (filled)	196308
Arcs (outline)	376309
Rounded rects (filled)	357910
Rounded rects (outline)	60438
```