### PR TITLE
Add gamma correction settings to ST7735

### DIFF
--- a/src/display/Arduino_ST7735.cpp
+++ b/src/display/Arduino_ST7735.cpp
@@ -59,9 +59,31 @@ void Arduino_ST7735::tftInit()
   {
     _bus->sendCommand(ST7735_INVON);
   }
-  _bus->sendCommand(ST7735_NORON); // 4: Normal display on, no args, w/delay
+
+  uint8_t gamma[] = {
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, ST7735_GMCTRP1,  // Gamma Adjustments (pos. polarity), 16 args:
+    WRITE_DATA_8, 16,
+    0x09, 0x16, 0x09, 0x20,           // (Not entirely necessary, but provides
+    0x21, 0x1B, 0x13, 0x19,           //  accurate colors)
+    0x17, 0x15, 0x1E, 0x2B,
+    0x04, 0x05, 0x02, 0x0E,
+    END_WRITE,
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, ST7735_GMCTRN1,  // Gamma Adjustments (neg. polarity), 16 args:
+    WRITE_DATA_8, 16,
+    0x0B, 0x14, 0x08, 0x1E,           // (Not entirely necessary, but provides
+    0x22, 0x1D, 0x18, 0x1E,           //  accurate colors)
+    0x1B, 0x1A, 0x24, 0x2B,
+    0x06, 0x06, 0x02, 0x0F,
+    END_WRITE,
+    DELAY, 10
+  };
+  _bus->batchOperation(gamma, sizeof(gamma)); // 4: Gamma correction
+
+  _bus->sendCommand(ST7735_NORON);  // 5: Normal display on, no args, w/delay
   delay(10);
-  _bus->sendCommand(ST7735_DISPON); // 5: Main screen turn on, no args, w/delay
+  _bus->sendCommand(ST7735_DISPON); // 6: Main screen turn on, no args, w/delay
 }
 
 void Arduino_ST7735::writeAddrWindow(int16_t x, int16_t y, uint16_t w, uint16_t h)


### PR DESCRIPTION
I noticed when migrating from another TFT library that the colours of some images was not not correct with this library and found that the other libraries all include gamma correction settings for the ST7735 display.
This PR adds the gamma correction settings from those libraries.

## Before
![IMG-0081](https://user-images.githubusercontent.com/512740/163267604-ec9100ca-1695-4040-9d25-d2156e40bd58.jpg)

## After
![IMG-0080](https://user-images.githubusercontent.com/512740/163267665-ad0e5c63-34e1-46fb-a013-6ad039ed7baa.jpg)

