### PR TITLE
Compile fix for SW SPI

### DIFF
--- a/src/databus/Arduino_SWSPI.cpp
+++ b/src/databus/Arduino_SWSPI.cpp
@@ -196,7 +196,9 @@ void Arduino_SWSPI::begin(int32_t speed, int8_t dataMode)
   _mosiPortClr = portClearRegister(_mosi);
   if (_miso != GFX_NOT_DEFINED)
   {
+#if !defined(KINETISK)
     _misoPinMask = digitalPinToBitMask(_miso);
+#endif
     _misoPort = (PORTreg_t)portInputRegister(digitalPinToPort(_miso));
   }
 #else  // !CORE_TEENSY


### PR DESCRIPTION
I ran into a compile error compiling for my teensy 3.2, looks to be a simple missing #ifdef as everything is fine after adding it in.

It's seems to happen regardless of the fact that in my project I was using `ArduinoGfx<Arduino_HWSPI, Arduino_ILI9486_18bit>` and not `Arduino_SWSPI`