### PR TITLE
Arduino_GFX: Export writeAddrWindow()

### DIFF
--- a/src/Arduino_GFX.cpp
+++ b/src/Arduino_GFX.cpp
@@ -2667,3 +2667,21 @@ void Arduino_GFX::displayOn()
 void Arduino_GFX::displayOff()
 {
 }
+
+/**************************************************************************/
+/*!
+  @brief  Write address window
+  @param  x   Start point x coordinate
+  @param  y   Start point y coordinate
+  @param  w   Width in pixels
+  @param  h   Height in pixels
+*/
+/**************************************************************************/
+void Arduino_GFX::writeAddrWindow(int16_t x, int16_t y, uint16_t w, uint16_t h)
+{
+  // Do nothing, must be subclassed if supported by hardware
+  UNUSED(x);
+  UNUSED(y);
+  UNUSED(w);
+  UNUSED(h);
+}

--- a/src/Arduino_GFX.h
+++ b/src/Arduino_GFX.h
@@ -163,6 +163,7 @@ public:
   virtual void invertDisplay(bool i);
   virtual void displayOn();
   virtual void displayOff();
+  virtual void writeAddrWindow(int16_t x, int16_t y, uint16_t w, uint16_t h);
 
   // BASIC DRAW API
   // These MAY be overridden by the subclass to provide device-specific


### PR DESCRIPTION
For performance reasons (like in LVGL...) someone may want to directly send pixel data to the screen, skipping all the boundary checks from other methods of this library (as the checks were already performed elsewhere, that would be double checking).

Make writeAddrWindow() usable from an external program, so that it becomes possible to get a slight performance increase in some use cases.

An example (LVGL):
```
void my_disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p)
{
   uint32_t w = (area->x2 - area->x1 + 1);
   uint32_t h = (area->y2 - area->y1 + 1);
   struct disp_hw *disphw = (struct disp_hw *)disp->user_data;

    disphw->bus->beginWrite();
    disphw->gfx->writeAddrWindow(area->x1, area->y1, w, h);
    disphw->bus->writePixels(&color_p->full, (uint32_t)w * h);
    disphw->bus->endWrite();

   lv_disp_flush_ready(disp);
}
```