### PR TITLE
Add an option to allow to disable color defines

### DIFF
--- a/src/Arduino_GFX.h
+++ b/src/Arduino_GFX.h
@@ -28,6 +28,7 @@
 #endif
 
 // Color definitions
+#ifndef DISABLE_COLOR_DEFINES
 #define BLACK 0x0000       ///<   0,   0,   0
 #define NAVY 0x000F        ///<   0,   0, 123
 #define DARKGREEN 0x03E0   ///<   0, 125,   0
@@ -47,6 +48,7 @@
 #define ORANGE 0xFD20      ///< 255, 165,   0
 #define GREENYELLOW 0xAFE5 ///< 173, 255,  41
 #define PINK 0xFC18        ///< 255, 130, 198
+#endif
 
 // Many (but maybe not all) non-AVR board installs define macros
 // for compatibility with existing PROGMEM-reading AVR code.


### PR DESCRIPTION
I'm working on a integration of your library into espHome. 

Today i found out that your color defines are also being defined inside some other components inside espHome.
I created a small fix that would disable your defines when DISABLE_COLOR_DEFINES are set.

Could you please add this in your library, thanks?  