### PR TITLE
Fix issue with a bunch of redefined warnings on STM32 boards with platformio

### DIFF
--- a/src/Arduino_DataBus.h
+++ b/src/Arduino_DataBus.h
@@ -102,7 +102,9 @@ typedef volatile ARDUINOGFX_PORT_t *PORTreg_t;
 #define SPI_DEFAULT_FREQ 24000000 ///< Default SPI data clock frequency
 #endif
 
+#ifndef UNUSED
 #define UNUSED(x) (void)(x)
+#endif
 #define ATTR_UNUSED __attribute__((unused))
 
 #define MSB_16_SET(var, val)                             \


### PR DESCRIPTION
Small PR to fix an issue I encountered with STM32 platform and platformio. `UNUSED` is already defined by the platform, so there are a bunch of compiler warnings when this library is used.

Simple preprocessor check ensures `UNUSED` is not redefined.