### PR TITLE
Support for building as an IDF 4.4.4 component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*
 *.txt
+!CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+get_filename_component(dir ${CMAKE_CURRENT_LIST_FILE} PATH)
+FILE(GLOB_RECURSE app_sources ${dir}/src/*.cpp)
+
+idf_component_register(SRCS ${app_sources}      
+                    REQUIRES wear_levelling esp_lcd Arduino Arduino_GFX
+                    INCLUDE_DIRS "src"
+)


### PR DESCRIPTION
Why IDF 4.4.4? Because IDF 4.4.5 wouldn't compile with arduino-esp32. And IDF5+ definitely won't yet (someday!).