### PR TITLE
Update Arduino_TFT.cpp

### DIFF
--- a/src/Arduino_TFT.cpp
+++ b/src/Arduino_TFT.cpp
@@ -454,10 +454,14 @@ void Arduino_TFT::drawIndexedBitmap(
   {
     startWrite();
     writeAddrWindow(x, y, w, h);
-    while (h--)
-    {
-      _bus->writeIndexedPixels(bitmap, color_index, w);
-      bitmap += w + x_skip;
+    if (x_skip == 0) {
+      _bus->writeIndexedPixels(bitmap, color_index, h*w);
+    } else {
+      while (h--)
+      {
+        _bus->writeIndexedPixels(bitmap, color_index, w);
+        bitmap += w + x_skip;
+      }
     }
     endWrite();
   }


### PR DESCRIPTION
don't split transfers with Arduino_DataBus::writeIndexedPixels() when x_skip is 0.

Unsplited transfer is in most cases faster and normal canvas flush happens with x_skip=0 and the code inside your bus class (f.e. Arduino_ESP32Spi) is very much optimized when you get bigger chunks (like 32 pixel at once).

If you split in lines even when not needed you might get a reminder per line (width%32) which slow down transfer. If you don't split this just happens ones.

I created a test case in your PDQgraphicstest.ino:

```C++

  // insert in main
  int32_t usecIndexedCanvas63 = testIndexedCanvas(63,128,50);
  serialOut(F("Flushing canvas (63x128 pixel, 50 times)\t"), usecIndexedCanvas63, 100, true);

  int32_t usecIndexedCanvas64 = testIndexedCanvas(64,128,50);
  serialOut(F("Flushing canvas (64x128 pixel, 50 times)\t"), usecIndexedCanvas64, 100, true);

// at end of file
int32_t testIndexedCanvas(uint16_t x,uint16_t y,uint16_t n)
{
  uint32_t start;

  Arduino_Canvas_Indexed * can = new Arduino_Canvas_Indexed(x  /* width */, y /* height */, gfx,1,1);

  if (!can->begin()) {
    Serial.println("Could not create canvas.");
    return -1;
  }
  //Serial.printf("Canvas %dx%d created.\n",can->width(),can->height());

  can->fillScreen(GREEN);
  can->setCursor(10,10);
  can->printf("Hello");

  start = micros_start();

  for (int i = 0; i < n; i++)
  {
    can->flush();
  }
  start = micros() - start;

  delete can;
  return start;
}
```

with ESP32_1732S019 as board, the results are:
original:
Flushing canvas (63x128 pixel, 50 times)        242477
Flushing canvas (64x128 pixel, 50 times)        200015

with change:
Flushing canvas (63x128 pixel, 50 times)        194670
Flushing canvas (64x128 pixel, 50 times)        197730

Ok, this might be a edge case, but it is a cheap gain, so please merge it in. 



