### PR TITLE
Arduino Compatibility issue with Arduino global identifiers

### DIFF
--- a/src/databus/Arduino_XL9535SWSPI.cpp
+++ b/src/databus/Arduino_XL9535SWSPI.cpp
@@ -17,14 +17,14 @@ bool Arduino_XL9535SWSPI::begin(int32_t, int8_t)
     if (_pwd != GFX_NOT_DEFINED)
     {
       // this->pinMode(_pwd, OUTPUT);
-      this->digitalWrite(_pwd, 1);
+      this->digitalWriteXL(_pwd, 1);
     }
     // this->pinMode(_cs, OUTPUT);
-    this->digitalWrite(_cs, 1);
+    this->digitalWriteXL(_cs, 1);
     // this->pinMode(_sck, OUTPUT);
-    this->digitalWrite(_sck, 1);
+    this->digitalWriteXL(_sck, 1);
     // this->pinMode(_mosi, OUTPUT);
-    this->digitalWrite(_mosi, 1);
+    this->digitalWriteXL(_mosi, 1);
   }
   else
   {
@@ -37,35 +37,35 @@ bool Arduino_XL9535SWSPI::begin(int32_t, int8_t)
 
 void Arduino_XL9535SWSPI::beginWrite()
 {
-  this->digitalWrite(_cs, 0);
+  this->digitalWriteXL(_cs, 0);
 }
 
 void Arduino_XL9535SWSPI::endWrite()
 {
-  this->digitalWrite(_cs, 1);
+  this->digitalWriteXL(_cs, 1);
 }
 
 void Arduino_XL9535SWSPI::writeCommand(uint8_t c)
 {
   // D/C bit, command
-  this->digitalWrite(_mosi, 0);
-  this->digitalWrite(_sck, 0);
-  this->digitalWrite(_sck, 1);
+  this->digitalWriteXL(_mosi, 0);
+  this->digitalWriteXL(_sck, 0);
+  this->digitalWriteXL(_sck, 1);
 
   uint8_t bit = 0x80;
   while (bit)
   {
     if (c & bit)
     {
-      this->digitalWrite(_mosi, 1);
+      this->digitalWriteXL(_mosi, 1);
     }
     else
     {
-      this->digitalWrite(_mosi, 0);
+      this->digitalWriteXL(_mosi, 0);
     }
-    this->digitalWrite(_sck, 0);
+    this->digitalWriteXL(_sck, 0);
     bit >>= 1;
-    this->digitalWrite(_sck, 1);
+    this->digitalWriteXL(_sck, 1);
   }
 }
 
@@ -76,24 +76,24 @@ void Arduino_XL9535SWSPI::writeCommand16(uint16_t)
 void Arduino_XL9535SWSPI::write(uint8_t d)
 {
   // D/C bit, data
-  this->digitalWrite(_mosi, 1);
-  this->digitalWrite(_sck, 0);
-  this->digitalWrite(_sck, 1);
+  this->digitalWriteXL(_mosi, 1);
+  this->digitalWriteXL(_sck, 0);
+  this->digitalWriteXL(_sck, 1);
 
   uint8_t bit = 0x80;
   while (bit)
   {
     if (d & bit)
     {
-      this->digitalWrite(_mosi, 1);
+      this->digitalWriteXL(_mosi, 1);
     }
     else
     {
-      this->digitalWrite(_mosi, 0);
+      this->digitalWriteXL(_mosi, 0);
     }
-    this->digitalWrite(_sck, 0);
+    this->digitalWriteXL(_sck, 0);
     bit >>= 1;
-    this->digitalWrite(_sck, 1);
+    this->digitalWriteXL(_sck, 1);
   }
 }
 
@@ -142,7 +142,7 @@ uint8_t Arduino_XL9535SWSPI::readRegister(uint8_t reg, uint8_t *data, size_t len
   return 0;
 }
 
-void Arduino_XL9535SWSPI::pinMode(uint8_t pin, uint8_t mode)
+void Arduino_XL9535SWSPI::pinModeXL(uint8_t pin, uint8_t mode)
 {
   if (is_found)
   {
@@ -199,7 +199,7 @@ void Arduino_XL9535SWSPI::pinMode8(uint8_t port, uint8_t pin, uint8_t mode)
   }
 }
 
-void Arduino_XL9535SWSPI::digitalWrite(uint8_t pin, uint8_t val)
+void Arduino_XL9535SWSPI::digitalWriteXL(uint8_t pin, uint8_t val)
 {
   if (is_found)
   {
@@ -226,7 +226,7 @@ void Arduino_XL9535SWSPI::digitalWrite(uint8_t pin, uint8_t val)
   }
 }
 
-int Arduino_XL9535SWSPI::digitalRead(uint8_t pin)
+int Arduino_XL9535SWSPI::digitalReadXL(uint8_t pin)
 {
   if (is_found)
   {

--- a/src/databus/Arduino_XL9535SWSPI.h
+++ b/src/databus/Arduino_XL9535SWSPI.h
@@ -35,11 +35,11 @@ public:
   void writeBytes(uint8_t *data, uint32_t len) override;
 #endif // !defined(LITTLE_FOOT_PRINT)
 
-  void pinMode(uint8_t pin, uint8_t mode);
+  void pinModeXL(uint8_t pin, uint8_t mode);
   void pinMode8(uint8_t port, uint8_t pin, uint8_t mode);
 
-  void digitalWrite(uint8_t pin, uint8_t val);
-  int digitalRead(uint8_t pin);
+  void digitalWriteXL(uint8_t pin, uint8_t val);
+  int digitalReadXL(uint8_t pin);
 
 protected:
   void writeRegister(uint8_t reg, uint8_t *data, size_t len);


### PR DESCRIPTION
The Arduino environment has some global functionalities that can be used without referencing a namespace or class.

Now we have the first official ESP32S3 board from Arduino in the Nano format. This comes with a re-assignment of the board pins (D0-D13 and A0-A7) to the real GPIOs.
when calling a standard Arduino function using a port number like `digitalWrite` the pin paramter is mapped to the GPIO using a function named `digitalPinToGPIONumber`.

However this is none using a C Macro and not by implementing inside the function intself. So `digitalWrite` is not a C /CPP identifiers but a C - Macro.
They create problems when using the same identifier as class members.

Example: `pinMode` as a class function in class `Arduino_XL9535SWSPI`.

The ESP32S3 (Arduino Nano ESP32) defines the following macros
in file "esp32/io_pin_remap.h" that is included in "Arduino.h"

```cpp
#define pinMode(pin, mode) pinMode(digitalPinToGPIONumber(pin), mode)
```

This is because the pin numbers for this board have some "renumbering" and the function `digitalPinToGPIONumber` is there to map the printed numbers to the GPIO.
(bad, but reality).

When you use this identifier in your code the above macro will apply - definitively unwanted in your library on the class function declarations.

So I renamed the funtions

* `pinMode` to  `pinModeXL`
* `digitalWrite` to `digitalWriteXL`
* `digitalRead` to `digitalReadXL`

in files: libraries/Arduino_GFX/src/databus/Arduino_XL9535SWSPI.h

As `pinMode` seems to be unused it may also just be removed.

Here is a pull request that fixes compilation for ESP32C3 boards.

