### PR TITLE
Monochrome OLED support using i2c

### DIFF
--- a/src/Arduino_GFX.cpp
+++ b/src/Arduino_GFX.cpp
@@ -2028,7 +2028,7 @@ void Arduino_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       return;
     }
 
-    // NOTE: Different from Adafruit_GFX design, Adruino_GFX also cater background.
+    // NOTE: Different from Adafruit_GFX design, Arduino_GFX also cater background.
     // Since it may introduce many ugly output, it should limited using on mono font only.
     startWrite();
     if (bg != color) // have background color

--- a/src/Arduino_GFX_Library.h
+++ b/src/Arduino_GFX_Library.h
@@ -35,6 +35,7 @@
 #include "databus/Arduino_SWPAR8.h"
 #include "databus/Arduino_SWPAR16.h"
 #include "databus/Arduino_SWSPI.h"
+#include "databus/Arduino_Wire.h"
 #include "databus/Arduino_XL9535SWSPI.h"
 #include "databus/Arduino_XCA9554SWSPI.h"
 
@@ -77,6 +78,7 @@
 #include "display/Arduino_RM67162.h"
 #include "display/Arduino_RGB_Display.h"
 #include "display/Arduino_SEPS525.h"
+#include "display/Arduino_SH1106.h"
 #include "display/Arduino_SSD1283A.h"
 #include "display/Arduino_SSD1331.h"
 #include "display/Arduino_SSD1351.h"

--- a/src/canvas/Arduino_Canvas_Mono.cpp
+++ b/src/canvas/Arduino_Canvas_Mono.cpp
@@ -4,8 +4,8 @@
 #include "../Arduino_GFX.h"
 #include "Arduino_Canvas_Mono.h"
 
-Arduino_Canvas_Mono::Arduino_Canvas_Mono(int16_t w, int16_t h, Arduino_G *output, int16_t output_x, int16_t output_y)
-    : Arduino_GFX(w, h), _output(output), _output_x(output_x), _output_y(output_y)
+Arduino_Canvas_Mono::Arduino_Canvas_Mono(int16_t w, int16_t h, Arduino_G *output, int16_t output_x, int16_t output_y, bool verticalByte)
+    : Arduino_GFX(w, h), _output(output), _output_x(output_x), _output_y(output_y), _verticalByte(verticalByte)
 {
 }
 
@@ -21,9 +21,12 @@ bool Arduino_Canvas_Mono::begin(int32_t speed)
 {
   if (speed != GFX_SKIP_OUTPUT_BEGIN)
   {
-    if (!_output->begin(speed))
+    if (_output)
     {
-      return false;
+      if (!_output->begin(speed))
+      {
+        return false;
+      }
     }
   }
 
@@ -53,21 +56,42 @@ bool Arduino_Canvas_Mono::begin(int32_t speed)
 
 void Arduino_Canvas_Mono::writePixelPreclipped(int16_t x, int16_t y, uint16_t color)
 {
-  int16_t w = (_width + 7) / 8;
-  int32_t pos = y * w + x / 8;
-  if (color & 0b1000010000010000)
+  if (_verticalByte)
   {
-    _framebuffer[pos] |= 0x80 >> (x & 7);
+    // vertical buffer layout: 1 byte in the buffer contains 8 vertical pixels
+    int32_t pos = x + (y / 8) * _width;
+
+    if (color & 0b1000010000010000)
+    {
+      _framebuffer[pos] |= (1 << (y & 7));
+    }
+    else
+    {
+      _framebuffer[pos] &= ~(1 << (y & 7));
+    }
   }
+
   else
   {
-    _framebuffer[pos] &= ~(0x80 >> (x & 7));
+    // horizontal buffer layout: 1 byte in the buffer contains 8 horizontal pixels
+    int16_t w = (_width + 7) / 8;
+    int32_t pos = y * w + x / 8;
+    
+    if (color & 0b1000010000010000)
+    {
+      _framebuffer[pos] |= 0x80 >> (x & 7);
+    }
+    else
+    {
+      _framebuffer[pos] &= ~(0x80 >> (x & 7));
+    }
   }
 }
 
 void Arduino_Canvas_Mono::flush()
 {
-  _output->drawBitmap(_output_x, _output_y, _framebuffer, _width, _height, WHITE, BLACK);
+  if (_output)
+    _output->drawBitmap(_output_x, _output_y, _framebuffer, _width, _height, WHITE, BLACK);
 }
 
 uint8_t *Arduino_Canvas_Mono::getFramebuffer()

--- a/src/canvas/Arduino_Canvas_Mono.h
+++ b/src/canvas/Arduino_Canvas_Mono.h
@@ -9,7 +9,7 @@
 class Arduino_Canvas_Mono : public Arduino_GFX
 {
 public:
-  Arduino_Canvas_Mono(int16_t w, int16_t h, Arduino_G *output, int16_t output_x = 0, int16_t output_y = 0);
+  Arduino_Canvas_Mono(int16_t w, int16_t h, Arduino_G *output, int16_t output_x = 0, int16_t output_y = 0, bool verticalByte = false);
   ~Arduino_Canvas_Mono();
 
   bool begin(int32_t speed = GFX_NOT_DEFINED) override;
@@ -22,6 +22,7 @@ protected:
   uint8_t *_framebuffer = nullptr;
   Arduino_G *_output = nullptr;
   int16_t _output_x, _output_y;
+  bool _verticalByte;
 
 private:
 };

--- a/src/databus/Arduino_Wire.cpp
+++ b/src/databus/Arduino_Wire.cpp
@@ -1,0 +1,93 @@
+// Databus Adapter for the Arduino Wire bus (I2C bus)
+
+#include "Arduino_Wire.h"
+
+Arduino_Wire::
+    Arduino_Wire(uint8_t i2c_addr, TwoWire *wire)
+    : _i2c_addr(i2c_addr), _wire(wire) {}
+
+bool Arduino_Wire::begin(int32_t, int8_t)
+{
+  _wire->begin();
+
+  // find device
+  _wire->beginTransmission(_i2c_addr);
+  if (_wire->endTransmission())
+  {
+    // Serial.println("Wire::Device not found.");
+    is_found = false;
+  }
+  else
+  {
+    is_found = true;
+  }
+
+  return is_found;
+}
+
+void Arduino_Wire::beginWrite()
+{
+  // Serial.println("Wire::beginWrite()");
+  _wire->beginTransmission(_i2c_addr);
+}
+
+void Arduino_Wire::endWrite()
+{
+  // Serial.println("\nWire::endWrite()");
+  _wire->endTransmission();
+}
+
+void Arduino_Wire::write(uint8_t d)
+{
+  // Serial.printf("(0x%02x) ", d);
+  _wire->write(d);
+}
+
+void Arduino_Wire::writeCommand(uint8_t c)
+{
+  // Serial.println("Wire::writeCommand()");
+  // not implemented.
+}
+
+void Arduino_Wire::writeCommand16(uint16_t)
+{
+  // Serial.println("Wire::writeCommand16()");
+  // not implemented.
+}
+
+void Arduino_Wire::write16(uint16_t)
+{
+  // Serial.println("Wire::write16()");
+  // not implemented
+}
+
+void Arduino_Wire::writeRepeat(uint16_t, uint32_t)
+{
+  // Serial.println("Wire::writeRepeat()");
+  // not implemented
+}
+
+void Arduino_Wire::writePixels(uint16_t *, uint32_t)
+{
+  // Serial.println("Wire::writePixels()");
+  // not implemented
+}
+
+#if !defined(LITTLE_FOOT_PRINT)
+void Arduino_Wire::writeBytes(uint8_t *data, uint32_t len)
+{
+  // Serial.println("Wire::writeBytes()");
+  // not implemented
+}
+#endif // !defined(LITTLE_FOOT_PRINT)
+
+void Arduino_Wire::writeRegister(uint8_t reg, uint8_t *data, size_t len)
+{
+  // Serial.println("Wire::writeRegister()");
+}
+
+uint8_t Arduino_Wire::readRegister(uint8_t reg, uint8_t *data, size_t len)
+{
+  // Serial.println("Wire::readRegister()");
+  return 0;
+}

--- a/src/databus/Arduino_Wire.h
+++ b/src/databus/Arduino_Wire.h
@@ -1,0 +1,41 @@
+// Databus Adapter for the Arduino Wire bus (I2C bus)
+
+#ifndef _Arduino_Wire_H_
+#define _Arduino_Wire_H_
+
+#include "Arduino_DataBus.h"
+#include <Wire.h>
+
+class Arduino_Wire : public Arduino_DataBus
+{
+public:
+  Arduino_Wire(uint8_t i2c_addr, TwoWire *wire = &Wire);
+
+  bool begin(int32_t speed = GFX_NOT_DEFINED, int8_t dataMode = GFX_NOT_DEFINED) override;
+  void beginWrite() override;
+  void endWrite() override;
+  void writeCommand(uint8_t) override;
+  void writeCommand16(uint16_t) override;
+  void write(uint8_t) override;
+  void write16(uint16_t) override;
+  void writeRepeat(uint16_t p, uint32_t len) override;
+  void writePixels(uint16_t *data, uint32_t len) override;
+
+#if !defined(LITTLE_FOOT_PRINT)
+  void writeBytes(uint8_t *data, uint32_t len) override;
+#endif // !defined(LITTLE_FOOT_PRINT)
+
+protected:
+  void writeRegister(uint8_t reg, uint8_t *data, size_t len);
+  uint8_t readRegister(uint8_t reg, uint8_t *data, size_t len);
+
+  uint8_t output_buf = 0;
+  bool is_found;
+
+  TwoWire *_wire;
+  uint8_t _i2c_addr;
+
+private:
+};
+
+#endif // _Arduino_Wire_H_

--- a/src/display/Arduino_SH1106.cpp
+++ b/src/display/Arduino_SH1106.cpp
@@ -1,0 +1,199 @@
+// Arduino GFX display driver for SH1106
+
+#include "Arduino_DataBus.h"
+#include "Arduino_SH1106.h"
+
+// See datasheet for explaining these definitions
+#define SH110X_MEMORYMODE 0x20
+#define SH110X_COLUMNADDR 0x21
+#define SH110X_PAGEADDR 0x22
+#define SH110X_SETCONTRAST 0x81
+#define SH110X_CHARGEPUMP 0x8D
+#define SH110X_SEGREMAP 0xA0
+#define SH110X_DISPLAYALLON_RESUME 0xA4
+#define SH110X_DISPLAYALLON 0xA5
+#define SH110X_NORMALDISPLAY 0xA6
+#define SH110X_INVERTDISPLAY 0xA7
+#define SH110X_SETMULTIPLEX 0xA8
+#define SH110X_DCDC 0xAD
+#define SH110X_DISPLAYOFF 0xAE
+#define SH110X_DISPLAYON 0xAF
+#define SH110X_SETPAGEADDR 0xB0
+#define SH110X_COMSCANINC 0xC0
+#define SH110X_COMSCANDEC 0xC8
+#define SH110X_SETDISPLAYOFFSET 0xD3
+#define SH110X_SETDISPLAYCLOCKDIV 0xD5
+#define SH110X_SETPRECHARGE 0xD9
+#define SH110X_SETCOMPINS 0xDA
+#define SH110X_SETVCOMDETECT 0xDB
+#define SH110X_SETDISPSTARTLINE 0xDC
+#define SH110X_SETLOWCOLUMN 0x00
+#define SH110X_SETHIGHCOLUMN 0x10
+#define SH110X_SETSTARTLINE 0x40
+
+Arduino_SH1106::Arduino_SH1106(Arduino_DataBus *bus, int8_t rst, int16_t w, int16_t h)
+    : Arduino_G(w, h), _width(w), _height(h), _bus(bus), _rst(rst)
+{
+  _rotation = 0;
+  _pages = (h + 7) / 8;
+}
+
+bool Arduino_SH1106::begin(int32_t speed)
+{
+  Serial.println("** begin()");
+
+  if (!_bus)
+  {
+    Serial.println("** bus not given");
+  }
+  else if (!_bus->begin(speed))
+  {
+    Serial.println("bus not started");
+    return false;
+  }
+
+  Serial.println("** Initialize Display");
+
+  if (_rst != GFX_NOT_DEFINED)
+  {
+    pinMode(_rst, OUTPUT);
+    digitalWrite(_rst, HIGH);
+    delay(20);
+    digitalWrite(_rst, LOW);
+    delay(20);
+    digitalWrite(_rst, HIGH);
+    delay(20);
+  }
+
+  static const uint8_t init_sequence[] = {
+      BEGIN_WRITE,
+      WRITE_BYTES, 26,
+      0x00, // sequence of commands, Co = 0, D/C = 0
+      SH110X_DISPLAYOFF,
+      SH110X_SETDISPLAYCLOCKDIV, 0x80, // 0xD5, 0x80,
+      SH110X_SETMULTIPLEX, 0x3F,       // 0xA8, 0x3F,
+      SH110X_SETDISPLAYOFFSET, 0x00,   // 0xD3, 0x00,
+      SH110X_SETSTARTLINE,             // 0x40
+      SH110X_DCDC, 0x8B,               // DC/DC on
+      SH110X_SEGREMAP + 1,             // 0xA1
+      SH110X_COMSCANDEC,               // 0xC8
+      SH110X_SETCOMPINS, 0x12,         // 0xDA, 0x12,
+      SH110X_SETCONTRAST, 0xFF,        // 0x81, 0xFF
+      SH110X_SETPRECHARGE, 0x1F,       // 0xD9, 0x1F,
+      SH110X_SETVCOMDETECT, 0x40,      // 0xDB, 0x40,
+      0x33,                            // Set VPP to 9V
+      SH110X_NORMALDISPLAY,
+      SH110X_MEMORYMODE, 0x10, // 0x20, 0x00
+      SH110X_DISPLAYALLON_RESUME,
+      END_WRITE,
+
+      DELAY, 100,
+
+      BEGIN_WRITE,
+      WRITE_BYTES, 2,
+      0x00, // Co = 0, D/C = 0
+      SH110X_DISPLAYON,
+      END_WRITE};
+
+  _bus->batchOperation(init_sequence, sizeof(init_sequence));
+
+  return true;
+}
+
+void Arduino_SH1106::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg)
+{
+  Serial.printf("drawBitmap %d/%d w:%d h:%d\n", xStart, yStart, w, h);
+
+  // transfer the whole bitmap
+  for (uint8_t p = 0; p < _pages; p++)
+  {
+
+    // start page sequence
+    uint8_t seq[] = {
+        BEGIN_WRITE,
+        WRITE_BYTES, 4,
+        0x00,                    // sequence of commands
+        SH110X_SETPAGEADDR + p,  // set page
+        SH110X_SETLOWCOLUMN + 2, // set column
+        SH110X_SETHIGHCOLUMN + 0,
+        END_WRITE};
+    _bus->batchOperation(seq, sizeof(seq));
+
+    // send out page data
+    uint8_t *pptr = bitmap + (p * w); // page start pointer
+    uint16_t bytesOut = 0;
+
+    for (int x = 0; x < w; x++)
+    {
+
+      if (!bytesOut)
+      {
+        _bus->beginWrite();
+        _bus->write(SH110X_SETSTARTLINE + 0);
+        bytesOut = 1;
+      }
+
+      _bus->write(*pptr);
+      pptr++;
+      bytesOut++;
+
+      if (bytesOut == TWI_BUFFER_LENGTH)
+      {
+        _bus->endWrite();
+        bytesOut = 0;
+      }
+    }
+    if (bytesOut)
+    {
+      _bus->endWrite();
+    }
+  }
+} // drawBitmap()
+
+void Arduino_SH1106::drawIndexedBitmap(int16_t, int16_t, uint8_t *, uint16_t *, int16_t, int16_t, int16_t)
+{
+  Serial.println("Not Implemented drawIndexedBitmap()");
+}
+
+void Arduino_SH1106::draw3bitRGBBitmap(int16_t, int16_t, uint8_t *bitmap, int16_t w, int16_t h)
+{
+  Serial.println("Not Implemented draw3bitRGBBitmap()");
+}
+
+void Arduino_SH1106::draw16bitRGBBitmap(int16_t, int16_t, uint16_t *, int16_t, int16_t)
+{
+  Serial.println("Not Implemented draw16bitRGBBitmap()");
+}
+
+void Arduino_SH1106::draw24bitRGBBitmap(int16_t, int16_t, uint8_t *, int16_t, int16_t)
+{
+  Serial.println("Not Implemented draw24bitRGBBitmap()");
+}
+
+void Arduino_SH1106::invertDisplay(bool i)
+{
+  // _bus->sendCommand(i ? ILI9488_INVON : ILI9488_INVOFF);
+}
+
+void Arduino_SH1106::displayOn(void)
+{
+  uint8_t seq[] = {
+      BEGIN_WRITE,
+      WRITE_BYTES, 2,
+      0x00, // sequence of commands
+      SH110X_DISPLAYON,
+      END_WRITE};
+  _bus->batchOperation(seq, sizeof(seq));
+}
+
+void Arduino_SH1106::displayOff(void)
+{
+  uint8_t seq[] = {
+      BEGIN_WRITE,
+      WRITE_BYTES, 2,
+      0x00, // sequence of commands
+      SH110X_DISPLAYOFF,
+      END_WRITE};
+  _bus->batchOperation(seq, sizeof(seq));
+}
+

--- a/src/display/Arduino_SH1106.h
+++ b/src/display/Arduino_SH1106.h
@@ -1,0 +1,37 @@
+// Arduino GFX display driver for SH1106
+
+#ifndef _Arduino_SH1106_H_
+#define _Arduino_SH1106_H_
+
+#include <Arduino.h>
+#include <Print.h>
+#include <Arduino_GFX.h>
+
+class Arduino_SH1106 : public Arduino_G
+{
+public:
+  Arduino_SH1106(Arduino_DataBus *bus, int8_t rst = GFX_NOT_DEFINED, int16_t w = 128, int16_t h = 64);
+
+  bool begin(int32_t speed = GFX_NOT_DEFINED) override;
+  void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg) override;
+  void drawIndexedBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint16_t *color_index, int16_t w, int16_t h, int16_t x_skip = 0) override;
+  void draw3bitRGBBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h) override;
+  void draw16bitRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w, int16_t h) override;
+  void draw24bitRGBBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h) override;
+
+  void invertDisplay(bool);
+  void displayOn();
+  void displayOff();
+
+protected:
+  Arduino_DataBus *_bus;
+  int8_t _width;  //
+  int8_t _height; //
+  int8_t _pages;  //
+  int8_t _rst;
+  uint8_t _rotation;
+
+private:
+};
+
+#endif // _Arduino_SH1106_H_


### PR DESCRIPTION
## Arduino Wire bus implementation

The Arduino Wire bus enables connecting displays using the i2c bus.
This is especially useful for smaller and monochrome displays.

To initialize the i2c bus the standard Wire configuration for the board can be used
by only specifying the i2c address:

```cpp
Arduino_DataBus *bus = new Arduino_Wire(i2cAddress);
```

When another special Wire interface should be used the Wire can be passed as a second parameter.

```cpp
  TwoWire *wire2 = new TwoWire();
  wire2->begin(SDA2, SCL2);
  bus = new Arduino_Wire(conf->i2cAddress, wire2);
```


