### PR TITLE
esp32lcd8 & esp32lcd16 buffer malloc at dma

### DIFF
--- a/src/databus/Arduino_ESP32LCD16.cpp
+++ b/src/databus/Arduino_ESP32LCD16.cpp
@@ -136,6 +136,7 @@ bool Arduino_ESP32LCD16::begin(int32_t speed, int8_t dataMode)
 
   _dma_chan = _i80_bus->dma_chan;
   _dmadesc = (dma_descriptor_t *)heap_caps_malloc(sizeof(dma_descriptor_t), MALLOC_CAP_DMA);
+  _buffer = (uint8_t *)heap_caps_aligned_alloc(16, LCD_MAX_PIXELS_AT_ONCE * 2, MALLOC_CAP_DMA);
 
   return true;
 }

--- a/src/databus/Arduino_ESP32LCD16.h
+++ b/src/databus/Arduino_ESP32LCD16.h
@@ -79,9 +79,9 @@ private:
 
   union
   {
-    uint8_t _buffer[LCD_MAX_PIXELS_AT_ONCE * 2] = {0};
-    uint16_t _buffer16[LCD_MAX_PIXELS_AT_ONCE];
-    uint32_t _buffer32[LCD_MAX_PIXELS_AT_ONCE / 2];
+    uint8_t* _buffer;
+    uint16_t* _buffer16;
+    uint32_t* _buffer32;
   };
 };
 

--- a/src/databus/Arduino_ESP32LCD8.cpp
+++ b/src/databus/Arduino_ESP32LCD8.cpp
@@ -155,7 +155,7 @@ bool Arduino_ESP32LCD8::begin(int32_t speed, int8_t dataMode)
 
   _dma_chan = _i80_bus->dma_chan;
   _dmadesc = (dma_descriptor_t *)heap_caps_malloc(sizeof(dma_descriptor_t), MALLOC_CAP_DMA);
-
+  _buffer = (uint8_t *)heap_caps_aligned_alloc(16, LCD_MAX_PIXELS_AT_ONCE * 2, MALLOC_CAP_DMA);
   return true;
 }
 

--- a/src/databus/Arduino_ESP32LCD8.h
+++ b/src/databus/Arduino_ESP32LCD8.h
@@ -70,9 +70,9 @@ private:
 
   union
   {
-    uint8_t _buffer[LCD_MAX_PIXELS_AT_ONCE * 2] = {0};
-    uint16_t _buffer16[LCD_MAX_PIXELS_AT_ONCE];
-    uint32_t _buffer32[LCD_MAX_PIXELS_AT_ONCE / 2];
+    uint8_t* _buffer;
+    uint16_t* _buffer16;
+    uint32_t* _buffer32;
   };
 };
 


### PR DESCRIPTION

![image](https://github.com/moononournation/Arduino_GFX/assets/24584225/39ca83f2-a5ab-4ede-a118-c5fedf8434d4)

when ESP32S3 psram enable, new Arduino_ESP32LCD8 or Arduino_ESP32LCD16 When called inside the function, the buffer address will be assigned to psram, causing an error when sending lcd dma