### PR TITLE
Wire Bus and Mono-Color OLED improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,7 @@ Some larger display require RGB + 3-bit SPI combo interface, This interface requ
 * <https://github.com/modi12jin/Arduino-ESP32-WEA2012.git>
 * <https://github.com/nopnop2002/esp-idf-parallel-tft.git>
 * <https://github.com/olikraus/u8g2.git>
+
+## Sponsor vs Support
+
+As you may already aware there are seldom sponsors in this project. Convert it in terms of man power, it is much lower than a manhour each month. So don't expect too much on the support. Expecially the feature not realted to my planned maker projects ;>

--- a/src/Arduino_DataBus.h
+++ b/src/Arduino_DataBus.h
@@ -295,7 +295,7 @@ public:
   virtual void writeC8D16D16(uint8_t c, uint16_t d1, uint16_t d2);
   virtual void writeC8D16D16Split(uint8_t c, uint16_t d1, uint16_t d2);
   virtual void writeRepeat(uint16_t p, uint32_t len) = 0;
-  virtual void writePixels(uint8_t *data, uint32_t len){};
+  virtual void writeBytes(uint8_t *data, uint32_t len) = 0;
   virtual void writePixels(uint16_t *data, uint32_t len) = 0;
 
   void sendCommand(uint8_t c);
@@ -305,7 +305,6 @@ public:
 
 #if !defined(LITTLE_FOOT_PRINT)
   virtual void batchOperation(const uint8_t *operations, size_t len);
-  virtual void writeBytes(uint8_t *data, uint32_t len) = 0;
   virtual void writePattern(uint8_t *data, uint8_t len, uint32_t repeat);
   virtual void writeIndexedPixels(uint8_t *data, uint16_t *idx, uint32_t len);
   virtual void writeIndexedPixelsDouble(uint8_t *data, uint16_t *idx, uint32_t len);

--- a/src/Arduino_DataBus.h
+++ b/src/Arduino_DataBus.h
@@ -114,7 +114,11 @@ typedef volatile ARDUINOGFX_PORT_t *PORTreg_t;
 #endif
 
 #ifndef TWI_BUFFER_LENGTH
+#if defined(I2C_BUFFER_LENGTH)
+#define TWI_BUFFER_LENGTH I2C_BUFFER_LENGTH
+#else
 #define TWI_BUFFER_LENGTH 32
+#endif
 #endif
 
 #ifndef UNUSED
@@ -122,7 +126,7 @@ typedef volatile ARDUINOGFX_PORT_t *PORTreg_t;
 #endif
 #define ATTR_UNUSED __attribute__((unused))
 
-#define MSB_16(val) (((val)&0xFF00) >> 8) | (((val)&0xFF) << 8)
+#define MSB_16(val) (((val) & 0xFF00) >> 8) | (((val) & 0xFF) << 8)
 #define MSB_16_SET(var, val) \
   {                          \
     (var) = MSB_16(val);     \
@@ -264,9 +268,17 @@ union
 class Arduino_DataBus
 {
 public:
+  enum option_key : uint16_t
+  {
+    TWI_COMMAND_PREFIX,
+    TWI_DATA_PREFIX
+  };
+
   Arduino_DataBus();
 
   void unused() { UNUSED(_data16); } // avoid compiler warning
+
+  virtual void setOption(option_key option_key, uint16_t option_value){};
 
   virtual bool begin(int32_t speed = SPI_DEFAULT_FREQ, int8_t dataMode = GFX_NOT_DEFINED) = 0;
   virtual void beginWrite() = 0;
@@ -281,6 +293,7 @@ public:
   virtual void writeC8D16D16(uint8_t c, uint16_t d1, uint16_t d2);
   virtual void writeC8D16D16Split(uint8_t c, uint16_t d1, uint16_t d2);
   virtual void writeRepeat(uint16_t p, uint32_t len) = 0;
+  virtual void writePixels(uint8_t *data, uint32_t len){};
   virtual void writePixels(uint16_t *data, uint32_t len) = 0;
 
   void sendCommand(uint8_t c);

--- a/src/canvas/Arduino_Canvas_Mono.cpp
+++ b/src/canvas/Arduino_Canvas_Mono.cpp
@@ -33,7 +33,18 @@ bool Arduino_Canvas_Mono::begin(int32_t speed)
 
   if (!_framebuffer)
   {
-    size_t s = (_width + 7) / 8 * _height;
+    size_t s;
+
+    // allocate memory by full bytes.
+    if (_verticalByte)
+    {
+      s = _canvas_width * (_canvas_height + 7) / 8;
+    }
+    else
+    {
+      s = (_canvas_width + 7) / 8 * _canvas_height;
+    }
+
 #if defined(ESP32)
     if (psramFound())
     {

--- a/src/databus/Arduino_Wire.cpp
+++ b/src/databus/Arduino_Wire.cpp
@@ -108,9 +108,11 @@ void Arduino_Wire::writePixels(uint16_t *, uint32_t)
   // not implemented
 }
 
+
+#if !defined(LITTLE_FOOT_PRINT)
 // write data to the bus using the data prefix
 // when len exceeds the TWI_BUFFER_LENGTH then a new transfer protocol is started.
-void Arduino_Wire::writePixels(uint8_t *data, uint32_t len)
+void Arduino_Wire::writeBytes(uint8_t *data, uint32_t len)
 {
   uint16_t bytesOut = 0;
 
@@ -139,12 +141,6 @@ void Arduino_Wire::writePixels(uint8_t *data, uint32_t len)
   }
 }
 
-#if !defined(LITTLE_FOOT_PRINT)
-void Arduino_Wire::writeBytes(uint8_t *data, uint32_t len)
-{
-  // println("Wire::writeBytes()");
-  // not implemented
-}
 #endif // !defined(LITTLE_FOOT_PRINT)
 
 void Arduino_Wire::writeRegister(uint8_t reg, uint8_t *data, size_t len)

--- a/src/databus/Arduino_Wire.cpp
+++ b/src/databus/Arduino_Wire.cpp
@@ -108,8 +108,6 @@ void Arduino_Wire::writePixels(uint16_t *, uint32_t)
   // not implemented
 }
 
-
-#if !defined(LITTLE_FOOT_PRINT)
 // write data to the bus using the data prefix
 // when len exceeds the TWI_BUFFER_LENGTH then a new transfer protocol is started.
 void Arduino_Wire::writeBytes(uint8_t *data, uint32_t len)
@@ -140,8 +138,6 @@ void Arduino_Wire::writeBytes(uint8_t *data, uint32_t len)
     bytesOut++;
   }
 }
-
-#endif // !defined(LITTLE_FOOT_PRINT)
 
 void Arduino_Wire::writeRegister(uint8_t reg, uint8_t *data, size_t len)
 {

--- a/src/databus/Arduino_Wire.h
+++ b/src/databus/Arduino_Wire.h
@@ -27,7 +27,6 @@ public:
   void write(uint8_t) override;
   void write16(uint16_t) override;
   void writeRepeat(uint16_t p, uint32_t len) override;
-  void writePixels(uint8_t *data, uint32_t len) override;
   void writePixels(uint16_t *data, uint32_t len) override;
 
 #if !defined(LITTLE_FOOT_PRINT)

--- a/src/databus/Arduino_Wire.h
+++ b/src/databus/Arduino_Wire.h
@@ -1,15 +1,23 @@
 // Databus Adapter for the Arduino Wire bus (I2C bus)
 
+// The setOption function was added to the Arduino_DataBus class to allow configuration fom the
+// display into the bus. This is helpful as the display chips require their specific protocol
+// behaviors. e.g. The D/C (data/command) switching is based on specific GPIO pin or the 9-th
+// bit in SPI. The TWI /Wire protocol adds a byte ino the protocol. 
+
 #ifndef _Arduino_Wire_H_
 #define _Arduino_Wire_H_
 
-#include "Arduino_DataBus.h"
 #include <Wire.h>
+#include "Arduino_DataBus.h"
 
 class Arduino_Wire : public Arduino_DataBus
 {
 public:
+  // Constructors
   Arduino_Wire(uint8_t i2c_addr, TwoWire *wire = &Wire);
+
+  void setOption(option_key option_key, uint16_t option_value) override;
 
   bool begin(int32_t speed = GFX_NOT_DEFINED, int8_t dataMode = GFX_NOT_DEFINED) override;
   void beginWrite() override;
@@ -19,6 +27,7 @@ public:
   void write(uint8_t) override;
   void write16(uint16_t) override;
   void writeRepeat(uint16_t p, uint32_t len) override;
+  void writePixels(uint8_t *data, uint32_t len) override;
   void writePixels(uint16_t *data, uint32_t len) override;
 
 #if !defined(LITTLE_FOOT_PRINT)
@@ -34,6 +43,10 @@ protected:
 
   uint8_t _i2c_addr;
   TwoWire *_wire;
+
+  bool _use_prefix;
+  uint8_t _command_prefix;
+  uint8_t _data_prefix;
 
   int32_t _speed;
 private:

--- a/src/databus/Arduino_Wire.h
+++ b/src/databus/Arduino_Wire.h
@@ -27,11 +27,8 @@ public:
   void write(uint8_t) override;
   void write16(uint16_t) override;
   void writeRepeat(uint16_t p, uint32_t len) override;
-  void writePixels(uint16_t *data, uint32_t len) override;
-
-#if !defined(LITTLE_FOOT_PRINT)
   void writeBytes(uint8_t *data, uint32_t len) override;
-#endif // !defined(LITTLE_FOOT_PRINT)
+  void writePixels(uint16_t *data, uint32_t len) override;
 
 protected:
   void writeRegister(uint8_t reg, uint8_t *data, size_t len);

--- a/src/display/Arduino_SH1106.cpp
+++ b/src/display/Arduino_SH1106.cpp
@@ -130,7 +130,7 @@ void Arduino_SH1106::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap,
     _bus->endWrite();
 
     _bus->beginWrite();
-    _bus->writePixels(pptr, w);
+    _bus->writeBytes(pptr, w);
     _bus->endWrite();
   }
 

--- a/src/display/Arduino_SH1106.cpp
+++ b/src/display/Arduino_SH1106.cpp
@@ -85,7 +85,7 @@ bool Arduino_SH1106::begin(int32_t speed)
       SH110X_SEGREMAP + 1,             // 0xA1
       SH110X_COMSCANDEC,               // 0xC8
       SH110X_SETCOMPINS, 0x12,         // 0xDA, 0x12,
-      SH110X_SETCONTRAST, 0xFF,        // 0x81, 0xFF
+      SH110X_SETCONTRAST, 0x80,        // 0x81, 0x80
       SH110X_SETPRECHARGE, 0x1F,       // 0xD9, 0x1F,
       SH110X_SETVCOMDETECT, 0x40,      // 0xDB, 0x40,
       0x33,                            // Set VPP to 9V

--- a/src/display/Arduino_SH1106.cpp
+++ b/src/display/Arduino_SH1106.cpp
@@ -74,8 +74,7 @@ bool Arduino_SH1106::begin(int32_t speed)
 
   static const uint8_t init_sequence[] = {
       BEGIN_WRITE,
-      WRITE_BYTES, 26,
-      0x00, // sequence of commands, Co = 0, D/C = 0
+      WRITE_C8_BYTES, 25, 
       SH110X_DISPLAYOFF,
       SH110X_SETDISPLAYCLOCKDIV, 0x80, // 0xD5, 0x80,
       SH110X_SETMULTIPLEX, 0x3F,       // 0xA8, 0x3F,
@@ -97,9 +96,7 @@ bool Arduino_SH1106::begin(int32_t speed)
       DELAY, 100,
 
       BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // Co = 0, D/C = 0
-      SH110X_DISPLAYON,
+      WRITE_COMMAND_8, SH110X_DISPLAYON,
       END_WRITE};
 
   _bus->batchOperation(init_sequence, sizeof(init_sequence));
@@ -110,9 +107,7 @@ bool Arduino_SH1106::begin(int32_t speed)
 void Arduino_SH1106::setBrightness(uint8_t brightness)
 {
   _bus->beginWrite();
-  _bus->write(SH110X_COMMAND);
-  _bus->write(SH110X_SETCONTRAST);
-  _bus->write(brightness);
+  _bus->writeC8D8(SH110X_SETCONTRAST, brightness);
   _bus->endWrite();
 }; // setBrightness
 
@@ -129,8 +124,7 @@ void Arduino_SH1106::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap,
 
     // start page sequence
     _bus->beginWrite();
-    _bus->write(SH110X_COMMAND);
-    _bus->write(SH110X_SETPAGEADDR + p);
+    _bus->writeCommand(SH110X_SETPAGEADDR + p);
     _bus->write(SH110X_SETLOWCOLUMN + 2); // set column
     _bus->write(SH110X_SETHIGHCOLUMN + 0);
     _bus->endWrite();

--- a/src/display/Arduino_SH1106.h
+++ b/src/display/Arduino_SH1106.h
@@ -12,7 +12,7 @@ public:
   Arduino_SH1106(Arduino_DataBus *bus, int8_t rst = GFX_NOT_DEFINED, int16_t w = 128, int16_t h = 64);
 
   bool begin(int32_t speed = GFX_NOT_DEFINED) override;
-  void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg) override;
+  void drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg) override;
   void drawIndexedBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint16_t *color_index, int16_t w, int16_t h, int16_t x_skip = 0) override;
   void draw3bitRGBBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h) override;
   void draw16bitRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w, int16_t h) override;
@@ -21,6 +21,7 @@ public:
   void invertDisplay(bool);
   void displayOn();
   void displayOff();
+  void setBrightness(uint8_t brightness);
 
 protected:
   Arduino_DataBus *_bus;

--- a/src/display/Arduino_SSD1306.cpp
+++ b/src/display/Arduino_SSD1306.cpp
@@ -3,10 +3,13 @@
 #include "Arduino_DataBus.h"
 #include "Arduino_SSD1306.h"
 
+#define SSD1306_COMMAND 0x00
+#define SSD1306_DATA 0x40
+
 // SSD1306 commands, See Datasheet
 #define SSD1306_MEMORYMODE 0x20
-#define SSD1306_COLUMNADDR 0x21
-#define SSD1306_PAGEADDR 0x22
+#define SSD1306_SETCOLUMNADDR 0x21
+#define SSD1306_SETPAGEADDR 0x22
 #define SSD1306_SETCONTRAST 0x81
 #define SSD1306_CHARGEPUMP 0x8D
 #define SSD1306_SEGREMAP 0xA0
@@ -25,6 +28,7 @@
 
 #define SSD1306_SETLOWCOLUMN 0x00
 #define SSD1306_SETHIGHCOLUMN 0x10
+#define SSD1306_SETPAGE 0xB0
 #define SSD1306_SETSTARTLINE 0x40
 
 #define SSD1306_RIGHT_HORIZONTAL_SCROLL 0x26
@@ -35,12 +39,17 @@
 #define SSD1306_ACTIVATE_SCROLL 0x2F
 #define SSD1306_SET_VERTICAL_SCROLL_AREA 0xA3
 
-Arduino_SSD1306::Arduino_SSD1306(Arduino_DataBus *bus, int8_t rst, int16_t w, int16_t h)
-    : Arduino_G(w, h), _bus(bus), _rst(rst)
+
+void Arduino_SSD1306::_commandList(uint8_t *commands, uint8_t len)
 {
-  _rotation = 0;
-  _pages = (h + 7) / 8;
+  while (len--)
+  {
+    _bus->sendCommand(*commands++);
+  }
 }
+
+Arduino_SSD1306::Arduino_SSD1306(Arduino_DataBus *bus, int8_t rst, int16_t w, int16_t h)
+    : Arduino_G(w, h), _bus(bus), _rst(rst) {}
 
 bool Arduino_SSD1306::begin(int32_t speed)
 {
@@ -55,6 +64,10 @@ bool Arduino_SSD1306::begin(int32_t speed)
     // println("SSD1306::bus not started");
     return false;
   }
+
+  // set options in case of TWI / Wire bus in use
+  _bus->setOption(Arduino_DataBus::TWI_COMMAND_PREFIX, SSD1306_COMMAND);
+  _bus->setOption(Arduino_DataBus::TWI_DATA_PREFIX, SSD1306_DATA);
 
   // println("SSD1306::Initialize Display");
 
@@ -71,8 +84,6 @@ bool Arduino_SSD1306::begin(int32_t speed)
 
   // display parameter default values
   uint8_t comPins = 0x12;
-  _colStart = 0;
-  _colEnd = WIDTH - 1;
 
   if ((WIDTH == 128) && (HEIGHT == 32))
   {
@@ -87,9 +98,7 @@ bool Arduino_SSD1306::begin(int32_t speed)
   else if ((WIDTH == 72) && (HEIGHT == 40))
   {
     comPins = 0x12;
-    _contrast = 0x82;
-    _colStart = 28;
-    _colEnd = 28 + WIDTH - 1;
+    _contrast = 0x2F; // 0x82;
   }
   else if ((WIDTH == 96) && (HEIGHT == 16))
   {
@@ -101,9 +110,7 @@ bool Arduino_SSD1306::begin(int32_t speed)
     // Other screen varieties -- TBD
   }
 
-  static const uint8_t init_sequence[] = {
-      BEGIN_WRITE,
-      WRITE_BYTES, 25,
+  uint8_t init_sequence[] = {
       SSD1306_DISPLAYOFF,                          // 0xAE
       SSD1306_SETCONTRAST, _contrast,              // 0x81 nn
       SSD1306_NORMALDISPLAY,                       // 0xA6
@@ -119,18 +126,12 @@ bool Arduino_SSD1306::begin(int32_t speed)
       SSD1306_SETVCOMDETECT, 0x40,                 // 0xDB 0x40
       SSD1306_CHARGEPUMP, 0x14,                    // 0x8D 0x14
       SSD1306_SETSTARTLINE | 0x0,                  // 0x40       line #0
-      SSD1306_DISPLAYALLON_RESUME,                 // 0xA4
-      END_WRITE,
+      SSD1306_DISPLAYALLON_RESUME                  // 0xA4
+  };
+  _commandList(init_sequence, sizeof(init_sequence));
 
-      DELAY, 100,
-
-      BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // Co = 0, D/C = 0
-      SSD1306_DISPLAYON,
-      END_WRITE};
-
-  _bus->batchOperation(init_sequence, sizeof(init_sequence));
+  delay(100);
+  _bus->sendCommand(SSD1306_DISPLAYON); // 0xAF
 
   return true;
 }
@@ -143,7 +144,7 @@ void Arduino_SSD1306::setBrightness(uint8_t brightness){
 
 void Arduino_SSD1306::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg)
 {
-  printf("SSD1306::drawBitmap %d/%d w:%d h:%d\n", xStart, yStart, w, h);
+  // printf("SSD1306::drawBitmap %d/%d w:%d h:%d\n", xStart, yStart, w, h);
   uint16_t bufferLength = TWI_BUFFER_LENGTH;
 
 #if 0
@@ -168,50 +169,27 @@ void Arduino_SSD1306::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap
 #endif
 
 #if 1
-  // transfer the whole bitmap
-  for (uint8_t p = 0; p < _pages; p++)
-  {
-    uint8_t *pptr = bitmap + (p * w); // page start pointer
-    uint16_t bytesOut = 0;
 
-    // start page sequence
-    _bus->beginWrite();
-    // ==> _bus->writeBytes( SSD1306_PAGEADDR);
+#if defined(ESP8266)
+  yield();
+#endif
 
-    _bus->write(SSD1306_PAGEADDR);
-    _bus->write(0);   // Page start address
-    _bus->write(0x7); // Page end (not really, but works here)
+  // set page / column range in use for writing
+  // output is written in pages with 8 bit height
 
-    _bus->write(SSD1306_COLUMNADDR);
-    _bus->write(_colStart);
-    _bus->write(_colEnd);
-     // set column
-    _bus->endWrite();
+  uint8_t draw_startup_sequence[] = {
+      SSD1306_SETPAGEADDR,
+      yStart / 8,
+      (yStart / 8) + ((h + 7) / 8) - 1,
 
-    // send out page data
-    for (int x = 0; x < w; x++)
-    {
-      if (!bytesOut)
-      {
-        _bus->beginWrite();
-        _bus->write((uint8_t)0x40);
-        bytesOut = 1;
-      }
+      SSD1306_SETCOLUMNADDR,
+      xStart,
+      xStart + w - 1};
+  _commandList(draw_startup_sequence, sizeof(draw_startup_sequence));
 
-      _bus->write(*pptr++);
-      bytesOut++;
-
-      if (bytesOut == bufferLength)
-      {
-        _bus->endWrite();
-        bytesOut = 0;
-      }
-    }
-    if (bytesOut)
-    {
-      _bus->endWrite();
-    }
-  }
+  _bus->beginWrite();
+  _bus->writePixels(bitmap, w * ((h + 7) / 8));
+  _bus->endWrite();
 #endif
 } // drawBitmap()
 
@@ -242,22 +220,10 @@ void Arduino_SSD1306::invertDisplay(bool i)
 
 void Arduino_SSD1306::displayOn(void)
 {
-  uint8_t seq[] = {
-      BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // sequence of commands
-      SSD1306_DISPLAYON,
-      END_WRITE};
-  _bus->batchOperation(seq, sizeof(seq));
+  _bus->sendCommand(SSD1306_DISPLAYON); // 0xAF
 }
 
 void Arduino_SSD1306::displayOff(void)
 {
-  uint8_t seq[] = {
-      BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // sequence of commands
-      SSD1306_DISPLAYOFF,
-      END_WRITE};
-  _bus->batchOperation(seq, sizeof(seq));
+  _bus->sendCommand(SSD1306_DISPLAYOFF); // 0xAE
 }

--- a/src/display/Arduino_SSD1306.cpp
+++ b/src/display/Arduino_SSD1306.cpp
@@ -39,7 +39,6 @@
 #define SSD1306_ACTIVATE_SCROLL 0x2F
 #define SSD1306_SET_VERTICAL_SCROLL_AREA 0xA3
 
-
 void Arduino_SSD1306::_commandList(uint8_t *commands, uint8_t len)
 {
   while (len--)
@@ -136,10 +135,11 @@ bool Arduino_SSD1306::begin(int32_t speed)
   return true;
 }
 
-void Arduino_SSD1306::setBrightness(uint8_t brightness){
-    // _sendCommand(SSD1306_SETCONTRAST);
-    // ??? _sendCommand((brightness < 50) ? 0 : _contrast); ???
-    // _sendCommand((brightness < 50) ? 0 : 0x8f);
+void Arduino_SSD1306::setBrightness(uint8_t brightness)
+{
+  _bus->beginWrite();
+  _bus->writeC8D8(SSD1306_SETCONTRAST, brightness);
+  _bus->endWrite();
 }; // setBrightness
 
 void Arduino_SSD1306::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg)

--- a/src/display/Arduino_SSD1306.cpp
+++ b/src/display/Arduino_SSD1306.cpp
@@ -188,7 +188,7 @@ void Arduino_SSD1306::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap
   _commandList(draw_startup_sequence, sizeof(draw_startup_sequence));
 
   _bus->beginWrite();
-  _bus->writePixels(bitmap, w * ((h + 7) / 8));
+  _bus->writeBytes(bitmap, w * ((h + 7) / 8));
   _bus->endWrite();
 #endif
 } // drawBitmap()

--- a/src/display/Arduino_SSD1306.h
+++ b/src/display/Arduino_SSD1306.h
@@ -24,14 +24,12 @@ public:
   void setBrightness(uint8_t brightness);
 
 protected:
+  void _commandList(uint8_t *commands, uint8_t len);
+
   Arduino_DataBus *_bus;
   int8_t _rst;
-  int8_t _pages;
-  uint8_t _rotation;
 
   uint8_t _contrast = 0x8F;
-  uint8_t _colStart;
-  uint8_t _colEnd;
 
 private:
 };


### PR DESCRIPTION
This pull request is further enriching the functionality around using the Wire / I2C / TWI bus for displays and
closing functionality gaps in the Mono-Color OLED displays using the Canvas Mono for drawing.

Enhancing WireBus functionality
Enhancing Arduino_Canvas_Mono functionality
SH1106 support
SSD1306 support

See also #404 and #399 
