### PR TITLE
Wire Bus and Mono-Color OLED improvements

### DIFF
--- a/src/canvas/Arduino_Canvas_Mono.cpp
+++ b/src/canvas/Arduino_Canvas_Mono.cpp
@@ -33,7 +33,18 @@ bool Arduino_Canvas_Mono::begin(int32_t speed)
 
   if (!_framebuffer)
   {
-    size_t s = (_width + 7) / 8 * _height;
+    size_t s;
+
+    // allocate memory by full bytes.
+    if (_verticalByte)
+    {
+      s = _canvas_width * (_canvas_height + 7) / 8;
+    }
+    else
+    {
+      s = (_canvas_width + 7) / 8 * _canvas_height;
+    }
+
 #if defined(ESP32)
     if (psramFound())
     {

--- a/src/databus/Arduino_Wire.h
+++ b/src/databus/Arduino_Wire.h
@@ -7,9 +7,12 @@
 #include <Wire.h>
 
 #ifndef TWI_BUFFER_LENGTH
+#if defined(I2C_BUFFER_LENGTH)
+#define TWI_BUFFER_LENGTH I2C_BUFFER_LENGTH
+#else
 #define TWI_BUFFER_LENGTH 32
 #endif
-
+#endif
 class Arduino_Wire : public Arduino_DataBus
 {
 public:

--- a/src/databus/Arduino_Wire.h
+++ b/src/databus/Arduino_Wire.h
@@ -13,7 +13,7 @@
 class Arduino_Wire : public Arduino_DataBus
 {
 public:
-  Arduino_Wire(uint8_t i2c_addr, TwoWire *wire = &Wire);
+  Arduino_Wire(uint8_t i2c_addr, int8_t commandPrefix, int8_t dataPrefix, TwoWire *wire = &Wire);
 
   bool begin(int32_t speed = GFX_NOT_DEFINED, int8_t dataMode = GFX_NOT_DEFINED) override;
   void beginWrite() override;
@@ -35,6 +35,9 @@ protected:
 
   uint8_t _i2c_addr;
   TwoWire *_wire;
+
+  uint8_t _command_prefix;
+  uint8_t _data_prefix;
 
   int32_t _speed;
 private:

--- a/src/display/Arduino_SH1106.cpp
+++ b/src/display/Arduino_SH1106.cpp
@@ -2,6 +2,37 @@
 
 #include "Arduino_SH1106.h"
 
+// See datasheet for explaining these definitions
+#define SH110X_COMMAND 0x00
+#define SH110X_DATA 0x40
+
+#define SH110X_MEMORYMODE 0x20
+#define SH110X_COLUMNADDR 0x21
+#define SH110X_PAGEADDR 0x22
+#define SH110X_SETCONTRAST 0x81
+#define SH110X_CHARGEPUMP 0x8D
+#define SH110X_SEGREMAP 0xA0
+#define SH110X_DISPLAYALLON_RESUME 0xA4
+#define SH110X_DISPLAYALLON 0xA5
+#define SH110X_NORMALDISPLAY 0xA6
+#define SH110X_INVERTDISPLAY 0xA7
+#define SH110X_SETMULTIPLEX 0xA8
+#define SH110X_DCDC 0xAD
+#define SH110X_DISPLAYOFF 0xAE
+#define SH110X_DISPLAYON 0xAF
+#define SH110X_SETPAGEADDR 0xB0
+#define SH110X_COMSCANINC 0xC0
+#define SH110X_COMSCANDEC 0xC8
+#define SH110X_SETDISPLAYOFFSET 0xD3
+#define SH110X_SETDISPLAYCLOCKDIV 0xD5
+#define SH110X_SETPRECHARGE 0xD9
+#define SH110X_SETCOMPINS 0xDA
+#define SH110X_SETVCOMDETECT 0xDB
+#define SH110X_SETDISPSTARTLINE 0xDC
+#define SH110X_SETLOWCOLUMN 0x00
+#define SH110X_SETHIGHCOLUMN 0x10
+#define SH110X_SETSTARTLINE 0x40
+
 Arduino_SH1106::Arduino_SH1106(Arduino_DataBus *bus, int8_t rst, int16_t w, int16_t h)
     : Arduino_G(w, h), _bus(bus), _rst(rst)
 {
@@ -11,19 +42,19 @@ Arduino_SH1106::Arduino_SH1106(Arduino_DataBus *bus, int8_t rst, int16_t w, int1
 
 bool Arduino_SH1106::begin(int32_t speed)
 {
-  // println("SH1106::begin()");
+  // printf("SH1106::begin()\n");
 
   if (!_bus)
   {
-    // println("SH1106::bus not given");
+    // printf("SH1106::bus not given\n");
   }
   else if (!_bus->begin(speed))
   {
-    // println("SH1106::bus not started");
+    // printf("SH1106::bus not started");
     return false;
   }
 
-  // println("SH1106::Initialize Display");
+  // printf("SH1106::Initialize Display\n");
 
   if (_rst != GFX_NOT_DEFINED)
   {
@@ -38,32 +69,28 @@ bool Arduino_SH1106::begin(int32_t speed)
 
   static const uint8_t init_sequence[] = {
       BEGIN_WRITE,
-      WRITE_BYTES, 26,
-      0x00, // sequence of commands, Co = 0, D/C = 0
-      SH110X_DISPLAYOFF,
-      SH110X_SETDISPLAYCLOCKDIV, 0x80, // 0xD5, 0x80,
-      SH110X_SETMULTIPLEX, 0x3F,       // 0xA8, 0x3F,
-      SH110X_SETDISPLAYOFFSET, 0x00,   // 0xD3, 0x00,
-      SH110X_SETSTARTLINE,             // 0x40
-      SH110X_DCDC, 0x8B,               // DC/DC on
-      SH110X_SEGREMAP + 1,             // 0xA1
-      SH110X_COMSCANDEC,               // 0xC8
-      SH110X_SETCOMPINS, 0x12,         // 0xDA, 0x12,
-      SH110X_SETCONTRAST, 0xFF,        // 0x81, 0xFF
-      SH110X_SETPRECHARGE, 0x1F,       // 0xD9, 0x1F,
-      SH110X_SETVCOMDETECT, 0x40,      // 0xDB, 0x40,
-      0x33,                            // Set VPP to 9V
-      SH110X_NORMALDISPLAY,
-      SH110X_MEMORYMODE, 0x10, // 0x20, 0x00
-      SH110X_DISPLAYALLON_RESUME,
+      WRITE_COMMAND_8, SH110X_DISPLAYOFF,
+      WRITE_COMMAND_16, SH110X_SETDISPLAYCLOCKDIV, 0x80, // 0xD5, 0x80,
+      WRITE_COMMAND_16, SH110X_SETMULTIPLEX, 0x3F,       // 0xA8, 0x3F,
+      WRITE_COMMAND_16, SH110X_SETDISPLAYOFFSET, 0x00,   // 0xD3, 0x00,
+      WRITE_COMMAND_8, SH110X_SETSTARTLINE,              // 0x40
+      WRITE_COMMAND_16, SH110X_DCDC, 0x8B,               // 0xAD, DC/DC on
+      WRITE_COMMAND_8, SH110X_SEGREMAP + 1,              // 0xA1
+      WRITE_COMMAND_8, SH110X_COMSCANDEC,                // 0xC8
+      WRITE_COMMAND_16, SH110X_SETCOMPINS, 0x12,         // 0xDA, 0x12,
+      WRITE_COMMAND_16, SH110X_SETCONTRAST, 0x80,        // 0x81, 0x80
+      WRITE_COMMAND_16, SH110X_SETPRECHARGE, 0x1F,       // 0xD9, 0x1F,
+      WRITE_COMMAND_16, SH110X_SETVCOMDETECT, 0x40,      // 0xDB, 0x40,
+      WRITE_COMMAND_8, 0x33,                             // Set VPP to 9V
+      WRITE_COMMAND_8, SH110X_NORMALDISPLAY,             // 0xA6
+      WRITE_COMMAND_16, SH110X_MEMORYMODE, 0x10,         // 0x20, 0x10
+      WRITE_COMMAND_8, SH110X_DISPLAYALLON_RESUME,       // 0xA4
       END_WRITE,
 
       DELAY, 100,
 
       BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // Co = 0, D/C = 0
-      SH110X_DISPLAYON,
+      WRITE_COMMAND_8, SH110X_DISPLAYON, // 0xAF
       END_WRITE};
 
   _bus->batchOperation(init_sequence, sizeof(init_sequence));
@@ -71,94 +98,67 @@ bool Arduino_SH1106::begin(int32_t speed)
   return true;
 }
 
+void Arduino_SH1106::setBrightness(uint8_t brightness)
+{
+  _bus->beginWrite();
+  _bus->writeC8D8(SH110X_SETCONTRAST, brightness);
+  _bus->endWrite();
+}; // setBrightness
+
 void Arduino_SH1106::drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h, uint16_t, uint16_t)
 {
-  // printf("SH1106::drawBitmap %d/%d w:%d h:%d\n", xStart, yStart, w, h);
+  // printf("SH1106::drawBitmap %d/%d w:%d h:%d\n", x, y, w, h);
   uint16_t bufferLength = TWI_BUFFER_LENGTH;
 
   // transfer the whole bitmap
-  for (uint8_t p = y / 8; p < h / 8; p++)
+  for (uint8_t p = (y / 8); p < (h / 8); p++)
   {
     uint8_t *pptr = bitmap + (p * w); // page start pointer
-    uint16_t bytesOut = 0;
 
     // start page sequence
     _bus->beginWrite();
-    _bus->write(0x00);
-    _bus->write(SH110X_SETPAGEADDR + p);
+    _bus->writeCommand(SH110X_SETPAGEADDR + p);
     _bus->write(SH110X_SETLOWCOLUMN + 2); // set column
     _bus->write(SH110X_SETHIGHCOLUMN + 0);
     _bus->endWrite();
 
-    // send out page data
-    for (int i = x; i < w; i++)
-    {
-      if (!bytesOut)
-      {
-        _bus->beginWrite();
-        _bus->write(SH110X_SETSTARTLINE + 0);
-        bytesOut = 1;
-      }
-
-      _bus->write(*pptr++);
-      bytesOut++;
-
-      if (bytesOut == bufferLength)
-      {
-        _bus->endWrite();
-        bytesOut = 0;
-      }
-    }
-    if (bytesOut)
-    {
-      _bus->endWrite();
-    }
+    _bus->beginWrite();
+    _bus->writeBytes(pptr, w);
+    _bus->endWrite();
   }
 } // drawBitmap()
 
 void Arduino_SH1106::drawIndexedBitmap(int16_t, int16_t, uint8_t *, uint16_t *, int16_t, int16_t, int16_t)
 {
-  // println("SH1106::Not Implemented drawIndexedBitmap()");
+  // printf("SH1106::Not Implemented drawIndexedBitmap()");
 }
 
 void Arduino_SH1106::draw3bitRGBBitmap(int16_t, int16_t, uint8_t *, int16_t, int16_t)
 {
-  // println("SH1106::Not Implemented draw3bitRGBBitmap()");
+  // printf("SH1106::Not Implemented draw3bitRGBBitmap()");
 }
 
 void Arduino_SH1106::draw16bitRGBBitmap(int16_t, int16_t, uint16_t *, int16_t, int16_t)
 {
-  // println("SH1106::Not Implemented draw16bitRGBBitmap()");
+  // printf("SH1106::Not Implemented draw16bitRGBBitmap()");
 }
 
 void Arduino_SH1106::draw24bitRGBBitmap(int16_t, int16_t, uint8_t *, int16_t, int16_t)
 {
-  // println("SH1106::Not Implemented draw24bitRGBBitmap()");
+  // printf("SH1106::Not Implemented draw24bitRGBBitmap()");
 }
 
 void Arduino_SH1106::invertDisplay(bool)
 {
-  // _bus->sendCommand(i ? ILI9488_INVON : ILI9488_INVOFF);
+  // printf("SH1106::Not Implemented invertDisplay()");
 }
 
 void Arduino_SH1106::displayOn(void)
 {
-  uint8_t seq[] = {
-      BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // sequence of commands
-      SH110X_DISPLAYON,
-      END_WRITE};
-  _bus->batchOperation(seq, sizeof(seq));
+  _bus->sendCommand(SH110X_DISPLAYON);
 }
 
 void Arduino_SH1106::displayOff(void)
 {
-  uint8_t seq[] = {
-      BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // sequence of commands
-      SH110X_DISPLAYOFF,
-      END_WRITE};
-  _bus->batchOperation(seq, sizeof(seq));
+  _bus->sendCommand(SH110X_DISPLAYOFF);
 }

--- a/src/display/Arduino_SH1106.h
+++ b/src/display/Arduino_SH1106.h
@@ -6,34 +6,6 @@
 #include "../Arduino_GFX.h"
 #include "../databus/Arduino_Wire.h"
 
-// See datasheet for explaining these definitions
-#define SH110X_MEMORYMODE 0x20
-#define SH110X_COLUMNADDR 0x21
-#define SH110X_PAGEADDR 0x22
-#define SH110X_SETCONTRAST 0x81
-#define SH110X_CHARGEPUMP 0x8D
-#define SH110X_SEGREMAP 0xA0
-#define SH110X_DISPLAYALLON_RESUME 0xA4
-#define SH110X_DISPLAYALLON 0xA5
-#define SH110X_NORMALDISPLAY 0xA6
-#define SH110X_INVERTDISPLAY 0xA7
-#define SH110X_SETMULTIPLEX 0xA8
-#define SH110X_DCDC 0xAD
-#define SH110X_DISPLAYOFF 0xAE
-#define SH110X_DISPLAYON 0xAF
-#define SH110X_SETPAGEADDR 0xB0
-#define SH110X_COMSCANINC 0xC0
-#define SH110X_COMSCANDEC 0xC8
-#define SH110X_SETDISPLAYOFFSET 0xD3
-#define SH110X_SETDISPLAYCLOCKDIV 0xD5
-#define SH110X_SETPRECHARGE 0xD9
-#define SH110X_SETCOMPINS 0xDA
-#define SH110X_SETVCOMDETECT 0xDB
-#define SH110X_SETDISPSTARTLINE 0xDC
-#define SH110X_SETLOWCOLUMN 0x00
-#define SH110X_SETHIGHCOLUMN 0x10
-#define SH110X_SETSTARTLINE 0x40
-
 class Arduino_SH1106 : public Arduino_G
 {
 public:
@@ -49,6 +21,7 @@ public:
   void invertDisplay(bool);
   void displayOn();
   void displayOff();
+  void setBrightness(uint8_t brightness);
 
 protected:
   Arduino_DataBus *_bus;

--- a/src/display/Arduino_SSD1306.cpp
+++ b/src/display/Arduino_SSD1306.cpp
@@ -70,31 +70,28 @@ bool Arduino_SSD1306::begin(int32_t speed)
 
   static const uint8_t init_sequence[] = {
       BEGIN_WRITE,
-      WRITE_BYTES, 25,
-      SSD1306_DISPLAYOFF,                          // 0xAE
-      SSD1306_SETCONTRAST, _contrast,              // 0x81 nn
-      SSD1306_NORMALDISPLAY,                       // 0xA6
-      SSD1306_DEACTIVATE_SCROLL,                   // 0x2E
-      SSD1306_MEMORYMODE, 0x00,                    // 0x20 00 Horizontal addressing mode
-      SSD1306_SEGREMAPINV,                         // 0xA1
-      SSD1306_SETMULTIPLEX, (uint8_t)(HEIGHT - 1), // 0xA8 nn
-      SSD1306_COMSCANDEC,                          // 0xC8
-      SSD1306_SETDISPLAYOFFSET, 0x00,              // 0xD3 00   no offset
-      SSD1306_SETCOMPINS, comPins,                 // 0xDA nn
-      SSD1306_SETDISPLAYCLOCKDIV, 0x80,            // 0xD5 0x80
-      SSD1306_SETPRECHARGE, 0x22,                  // 0xd9 0x22
-      SSD1306_SETVCOMDETECT, 0x40,                 // 0xDB 0x40
-      SSD1306_CHARGEPUMP, 0x14,                    // 0x8D 0x14
-      SSD1306_SETSTARTLINE | 0x0,                  // 0x40       line #0
-      SSD1306_DISPLAYALLON_RESUME,                 // 0xA4
+      WRITE_COMMAND_8, SSD1306_DISPLAYOFF,                           // 0xAE
+      WRITE_C8_D8, SSD1306_SETCONTRAST, _contrast,              // 0x81 nn
+      WRITE_COMMAND_8, SSD1306_NORMALDISPLAY,                        // 0xA6
+      WRITE_COMMAND_8, SSD1306_DEACTIVATE_SCROLL,                    // 0x2E
+      WRITE_C8_D8, SSD1306_MEMORYMODE, 0x00,                    // 0x20 00 Horizontal addressing mode
+      WRITE_COMMAND_8, SSD1306_SEGREMAPINV,                          // 0xA1
+      WRITE_C8_D8, SSD1306_SETMULTIPLEX, (uint8_t)(HEIGHT - 1), // 0xA8 nn
+      WRITE_COMMAND_8, SSD1306_COMSCANDEC,                           // 0xC8
+      WRITE_C8_D8, SSD1306_SETDISPLAYOFFSET, 0x00,              // 0xD3 00   no offset
+      WRITE_C8_D8, SSD1306_SETCOMPINS, comPins,                 // 0xDA nn
+      WRITE_C8_D8, SSD1306_SETDISPLAYCLOCKDIV, 0x80,            // 0xD5 0x80
+      WRITE_C8_D8, SSD1306_SETPRECHARGE, 0x22,                  // 0xd9 0x22
+      WRITE_C8_D8, SSD1306_SETVCOMDETECT, 0x40,                 // 0xDB 0x40
+      WRITE_C8_D8, SSD1306_CHARGEPUMP, 0x14,                    // 0x8D 0x14
+      WRITE_COMMAND_8, SSD1306_SETSTARTLINE | 0x0,                   // 0x40       line #0
+      WRITE_COMMAND_8, SSD1306_DISPLAYALLON_RESUME,                  // 0xA4
       END_WRITE,
 
       DELAY, 100,
 
       BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // Co = 0, D/C = 0
-      SSD1306_DISPLAYON,
+      WRITE_COMMAND_8, SSD1306_DISPLAYON, // 0xAF
       END_WRITE};
 
   _bus->batchOperation(init_sequence, sizeof(init_sequence));
@@ -112,9 +109,10 @@ void Arduino_SSD1306::setBrightness(uint8_t /* brightness */)
 void Arduino_SSD1306::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap, int16_t w, int16_t h, uint16_t /* color */, uint16_t /* bg */)
 {
   printf("SSD1306::drawBitmap %d/%d w:%d h:%d\n", xStart, yStart, w, h);
-  uint16_t bufferLength = TWI_BUFFER_LENGTH;
+  uint16_t count = w * ((h + 7) / 8);
 
 #if 0
+  // text output
   // print bitmap on Serial log
   for (int y = 0; y < h; y++)
   {
@@ -135,52 +133,49 @@ void Arduino_SSD1306::drawBitmap(int16_t xStart, int16_t yStart, uint8_t *bitmap
   Serial.println();
 #endif
 
+
 #if 1
-  // transfer the whole bitmap
-  for (uint8_t p = 0; p < _pages; p++)
-  {
-    uint8_t *pptr = bitmap + (p * w); // page start pointer
-    uint16_t bytesOut = 0;
+  // I2C version
 
-    // start page sequence
-    _bus->beginWrite();
-    // ==> _bus->writeBytes( SSD1306_PAGEADDR);
+  // start page sequence
+  _bus->beginWrite();
+  // _bus->writeC8D16(SSD1306_PAGEADDR, (0x00 << 8) | 0xFF);
+  _bus->writeCommand(SSD1306_PAGEADDR);
+  _bus->write(0);    // Page start address
+  _bus->write(0xFF); // Page end (not really, but works here)
 
-    _bus->write(SSD1306_PAGEADDR);
-    _bus->write(0);   // Page start address
-    _bus->write(0x7); // Page end (not really, but works here)
+  // _bus->writeC8D16(SSD1306_COLUMNADDR, (_colStart << 8) | _colEnd);
+  _bus->writeCommand(SSD1306_COLUMNADDR);
+  _bus->write(_colStart);
+  _bus->write(_colEnd);
+  _bus->endWrite();
 
-    _bus->write(SSD1306_COLUMNADDR);
-    _bus->write(_colStart);
-    _bus->write(_colEnd);
-    // set column
-    _bus->endWrite();
+  _bus->beginWrite();
+  _bus->writeBytes(bitmap, count);
+  _bus->endWrite();
 
-    // send out page data
-    for (int x = 0; x < w; x++)
-    {
-      if (!bytesOut)
-      {
-        _bus->beginWrite();
-        _bus->write((uint8_t)0x40);
-        bytesOut = 1;
-      }
-
-      _bus->write(*pptr++);
-      bytesOut++;
-
-      if (bytesOut == bufferLength)
-      {
-        _bus->endWrite();
-        bytesOut = 0;
-      }
-    }
-    if (bytesOut)
-    {
-      _bus->endWrite();
-    }
-  }
 #endif
+
+#if 0
+  // SPI version
+
+  _bus->beginWrite();
+
+  digitalWrite(D1, LOW);
+  _bus->write(SSD1306_PAGEADDR);
+  _bus->write(0x00);
+  _bus->write(0xFF);
+  _bus->write(SSD1306_COLUMNADDR);
+  _bus->write(_colStart);
+  _bus->write(_colEnd);
+  digitalWrite(D1, HIGH);
+  _bus->endWrite();
+
+  _bus->beginWrite();
+  _bus->writeBytes(bitmap, count);
+  _bus->endWrite();
+#endif
+
 } // drawBitmap()
 
 void Arduino_SSD1306::drawIndexedBitmap(int16_t, int16_t, uint8_t *, uint16_t *, int16_t, int16_t, int16_t)
@@ -210,22 +205,10 @@ void Arduino_SSD1306::invertDisplay(bool)
 
 void Arduino_SSD1306::displayOn(void)
 {
-  uint8_t seq[] = {
-      BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // sequence of commands
-      SSD1306_DISPLAYON,
-      END_WRITE};
-  _bus->batchOperation(seq, sizeof(seq));
+  _bus->sendCommand(SSD1306_DISPLAYON);
 }
 
 void Arduino_SSD1306::displayOff(void)
 {
-  uint8_t seq[] = {
-      BEGIN_WRITE,
-      WRITE_BYTES, 2,
-      0x00, // sequence of commands
-      SSD1306_DISPLAYOFF,
-      END_WRITE};
-  _bus->batchOperation(seq, sizeof(seq));
+  _bus->sendCommand(SSD1306_DISPLAYOFF);
 }


### PR DESCRIPTION
This pull request is further enriching the functionality around using the Wire / I2C / TWI bus for displays and
closing functionality gaps in the Mono-Color OLED displays using the Canvas Mono for drawing.

Enhancing WireBus functionality
SH1106 support
SSD1306 support