### PR TITLE
Add `clip` argument to getTextBounds to allow calculation of real text size even if it overflows sreen

### DIFF
--- a/src/Arduino_GFX.cpp
+++ b/src/Arduino_GFX.cpp
@@ -2883,17 +2883,19 @@ void Arduino_GFX::charBounds(char c, int16_t *x, int16_t *y,
 /**************************************************************************/
 /*!
   @brief  Helper to determine size of a string with current font/size. Pass string and a cursor position, returns UL corner and W,H.
-  @param  str The ascii string to measure
-  @param  x   The current cursor X
-  @param  y   The current cursor Y
-  @param  x1  The boundary X coordinate, set by function
-  @param  y1  The boundary Y coordinate, set by function
-  @param  w   The boundary width, set by function
-  @param  h   The boundary height, set by function
+  @param  str  The ascii string to measure
+  @param  x    The current cursor X
+  @param  y    The current cursor Y
+  @param  x1   The boundary X coordinate, set by function
+  @param  y1   The boundary Y coordinate, set by function
+  @param  w    The boundary width, set by function
+  @param  h    The boundary height, set by function
+  @param  clip Whether to limit the result to the screen size (default is true)
 */
 /**************************************************************************/
 void Arduino_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
-                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h)
+                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h,
+                                bool clip)
 {
   uint8_t c; // Current character
 
@@ -2908,53 +2910,59 @@ void Arduino_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
     charBounds(c, &x, &y, &minx, &miny, &maxx, &maxy);
   }
 
-  if (maxx >= minx)
-  {
-    *x1 = minx;
-    *w = maxx - minx + 1;
-  }
-  if (maxy >= miny)
-  {
-    *y1 = miny;
-    *h = maxy - miny + 1;
+  if (clip) {
+    if (maxx >= minx)
+    {
+      *x1 = minx;
+      *w = maxx - minx + 1;
+    }
+    if (maxy >= miny)
+    {
+      *y1 = miny;
+      *h = maxy - miny + 1;
+    }
   }
 }
 
 /**************************************************************************/
 /*!
   @brief  Helper to determine size of a string with current font/size. Pass string and a cursor position, returns UL corner and W,H.
-  @param  str The ascii string to measure (as an arduino String() class)
-  @param  x   The current cursor X
-  @param  y   The current cursor Y
-  @param  x1  The boundary X coordinate, set by function
-  @param  y1  The boundary Y coordinate, set by function
-  @param  w   The boundary width, set by function
-  @param  h   The boundary height, set by function
+  @param  str  The ascii string to measure (as an arduino String() class)
+  @param  x    The current cursor X
+  @param  y    The current cursor Y
+  @param  x1   The boundary X coordinate, set by function
+  @param  y1   The boundary Y coordinate, set by function
+  @param  w    The boundary width, set by function
+  @param  h    The boundary height, set by function
+  @param  clip Whether to limit the result to the screen size (default is true)
 */
 /**************************************************************************/
 void Arduino_GFX::getTextBounds(const String &str, int16_t x, int16_t y,
-                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h)
+                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h,
+                                bool clip)
 {
   if (str.length() != 0)
   {
-    getTextBounds(const_cast<char *>(str.c_str()), x, y, x1, y1, w, h);
+    getTextBounds(const_cast<char *>(str.c_str()), x, y, x1, y1, w, h, clip);
   }
 }
 
 /**************************************************************************/
 /*!
   @brief  Helper to determine size of a PROGMEM string with current font/size. Pass string and a cursor position, returns UL corner and W,H.
-  @param  str The flash-memory ascii string to measure
-  @param  x   The current cursor X
-  @param  y   The current cursor Y
-  @param  x1  The boundary X coordinate, set by function
-  @param  y1  The boundary Y coordinate, set by function
-  @param  w   The boundary width, set by function
-  @param  h   The boundary height, set by function
+  @param  str  The flash-memory ascii string to measure
+  @param  x    The current cursor X
+  @param  y    The current cursor Y
+  @param  x1   The boundary X coordinate, set by function
+  @param  y1   The boundary Y coordinate, set by function
+  @param  w    The boundary width, set by function
+  @param  h    The boundary height, set by function
+  @param  clip Whether to limit the result to the screen size (default is true)
 */
 /**************************************************************************/
 void Arduino_GFX::getTextBounds(const __FlashStringHelper *str,
-                                int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h)
+                                int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h,
+                                bool clip)
 {
   uint8_t *s = (uint8_t *)str, c;
 
@@ -2967,15 +2975,17 @@ void Arduino_GFX::getTextBounds(const __FlashStringHelper *str,
   while ((c = pgm_read_byte(s++)))
     charBounds(c, &x, &y, &minx, &miny, &maxx, &maxy);
 
-  if (maxx >= minx)
-  {
-    *x1 = minx;
-    *w = maxx - minx + 1;
-  }
-  if (maxy >= miny)
-  {
-    *y1 = miny;
-    *h = maxy - miny + 1;
+  if (clip) {
+    if (maxx >= minx)
+    {
+      *x1 = minx;
+      *w = maxx - minx + 1;
+    }
+    if (maxy >= miny)
+    {
+      *y1 = miny;
+      *h = maxy - miny + 1;
+    }
   }
 }
 

--- a/src/Arduino_GFX.h
+++ b/src/Arduino_GFX.h
@@ -222,9 +222,9 @@ public:
   void draw16bitRGBBitmapWithMask(int16_t x, int16_t y, const uint16_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
   void draw24bitRGBBitmap(int16_t x, int16_t y, const uint8_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
   void draw24bitRGBBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
-  void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
-  void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
-  void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
+  void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
+  void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
   void setTextSize(uint8_t s);
   void setTextSize(uint8_t sx, uint8_t sy);
   void setTextSize(uint8_t sx, uint8_t sy, uint8_t pixel_margin);


### PR DESCRIPTION
When implementing things like horizontally scrolling text which overflows screen, `getTextBounds` limits output to screen width, which is very inconvenient.

This PR adds a `clip` argument to `getTextBounds` (defaults to `true` for backward compatibility). By passing `false`, these functions will return actual text size irregardless of screen size.