### PR TITLE
Arduino_ESP32SPI::writeBytesDMA(...)

### DIFF
--- a/src/databus/Arduino_ESP32SPI.h
+++ b/src/databus/Arduino_ESP32SPI.h
@@ -4,6 +4,7 @@
 
 #if defined(ESP32)
 #include "soc/spi_struct.h"
+#include "driver/spi_master.h"
 #if CONFIG_IDF_TARGET_ESP32S3
 #if (ESP_ARDUINO_VERSION_MAJOR < 3)
 #include "driver/periph_ctrl.h"
@@ -58,6 +59,8 @@ public:
   void writeIndexedPixels(uint8_t *data, uint16_t *idx, uint32_t len) override;
   void writeIndexedPixelsDouble(uint8_t *data, uint16_t *idx, uint32_t len) override;
 
+  bool isDMABusy();
+  void writeBytesDMA(uint8_t *data, uint32_t len);
 protected:
   void flush_data_buf();
   INLINE void WRITE8BIT(uint8_t d);
@@ -69,6 +72,8 @@ protected:
   INLINE void POLL(uint32_t len);
 
 private:
+  void waitForDMA();
+
   int8_t _dc, _cs;
   int8_t _sck, _mosi, _miso;
   uint8_t _spi_num;
@@ -93,6 +98,13 @@ private:
   };
 
   uint16_t _data_buf_bit_idx = 0;
+
+  // writeBytesDMA(...) related
+  spi_device_handle_t _handle;
+  bool _dma_busy = false;
+  static constexpr int max_dma_transfer_sz =
+      TFT_WIDTH * TFT_HEIGHT * sizeof(uint16_t);
+  // --
 };
 
 #endif // #if defined(ESP32)


### PR DESCRIPTION
Arduino_ESP32SPI with addition 'writeBytesDMA(...)' doubling performance over 'writeBytes(...)' in use case described below.

Tested on ESP32-2432S028R.

```
...
#include <Arduino_GFX_Library.h>
#define GFX_BL 21
static Arduino_ESP32SPI bus{2 /* DC */, 15 /* CS */, 14 /* SCK */, 13 /* MOSI */, 12 /* MISO */};
static Arduino_ILI9341 display{&bus, GFX_NOT_DEFINED /* RST */, display_orientation};
...
void setup() {
  ...
  // initiate display
  if (!display.begin(SPI_FREQUENCY)) {
    ESP_LOGE("bam", "could not initiate Arduino_GFX");
    exit(1);
  }
  pinMode(GFX_BL, OUTPUT);
  digitalWrite(GFX_BL, HIGH);
  display.setAddrWindow(0, 0, display_width, display_height);
  display.startWrite();
  ...
}

void loop() {
  while (scanlines_left_to_render) {
    ...
    bus.writeBytesDMA(
      reinterpret_cast<uint8_t *>(dma_buf),
      uint32_t(display_width * dma_n_scanlines * sizeof(uint16_t)));
    dma_buf = dma_buf_use_first ? dma_buf_1 : dma_buf_2;
    dma_buf_use_first = !dma_buf_use_first;
    ...
  }
}
```
