### PR TITLE
Prevent overriding of '#define INLINE'

### DIFF
--- a/src/Arduino_DataBus.h
+++ b/src/Arduino_DataBus.h
@@ -136,11 +136,13 @@ typedef volatile ARDUINOGFX_PORT_t *PORTreg_t;
     (var) = ((uint32_t)a[0] << 8 | a[1] | a[2] << 24 | a[3] << 16); \
   }
 
+#ifndef INLINE
 #if !defined(LITTLE_FOOT_PRINT)
 #define INLINE __attribute__((always_inline)) inline
 #else
 #define INLINE inline
 #endif // !defined(LITTLE_FOOT_PRINT)
+#endif  // INLINE
 
 #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
 #if (ESP_ARDUINO_VERSION_MAJOR < 3)


### PR DESCRIPTION
'#define INLINE' is used frequently in other libs, unprotected override results in tons on compiler warnings like this: `warning: "INLINE" redefined`

This PR will protect it with `#ifndef` guard and prevent warnings in case global `INLINE` is defined