### PR TITLE
xSemaphoreHandle is deprecated

### DIFF
--- a/src/databus/Arduino_ESP32SPI.cpp
+++ b/src/databus/Arduino_ESP32SPI.cpp
@@ -10,7 +10,7 @@ struct spi_struct_t
 {
   spi_dev_t *dev;
 #if !CONFIG_DISABLE_HAL_LOCKS
-  xSemaphoreHandle lock;
+  SemaphoreHandle_t lock;
 #endif
   uint8_t num;
 };


### PR DESCRIPTION
xSemaphoreHandle is kinda deprecated in ESP_IDF 5 and ESP32 Arduino 3. Most builds will still support it, but some might not