### PR TITLE
Add Optional Read Operations, No DC HWSPI and virtuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@ Arduino_GFX is a Arduino graphics library supporting various displays with vario
 
 This library start rewrite from Adafruit_GFX, LovyanGFX, TFT_eSPI, Ucglib, and more...
 
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/moononournation/Arduino_GFX)
-![GitHub Release Date](https://img.shields.io/github/release-date/moononournation/Arduino_GFX)
-![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/moononournation/Arduino_GFX/latest)
-![GitHub last commit](https://img.shields.io/github/last-commit/moononournation/Arduino_GFX)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/moononournation/Arduino_GFX)![GitHub Release Date](https://img.shields.io/github/release-date/moononournation/Arduino_GFX)![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/moononournation/Arduino_GFX/latest)![GitHub last commit](https://img.shields.io/github/last-commit/moononournation/Arduino_GFX)
 
-![GitHub Sponsors](https://img.shields.io/github/sponsors/moononournation)
-![Twitter Follow](https://img.shields.io/twitter/follow/moononournation)
+![GitHub Sponsors](https://img.shields.io/github/sponsors/moononournation)![Twitter Follow](https://img.shields.io/twitter/follow/moononournation)
 
 ## Ease of use
 
@@ -55,7 +51,6 @@ If you are using below listed support dev device, simply select the Arduino_GFX_
 If you are not using supported dev device:
 
 - Default DataBus is using Arduino SPI. Other DataBus can modify in Arduino_GFX_databus.h.
-
 - Default Display is using ILI9341 LCD. Other Display can modify in Arduino_GFX_display.h.
 
 ## More Details
@@ -225,23 +220,23 @@ Below are some figures compare with other 3 Arduino common display libraries.
 * SPI Frequency: 40MHz
 * Test time: 2021 Jun 16
 
-| Benchmark          |  Adafruit_GFX | *Arduino_GFX* |    Lovyan_GFX |      TFT_eSPI |
-| ------------------ | ------------- | ------------- | ------------- | ------------- |
-| Screen fill        |       195,782 |     *160,094* |       154,341 |       155,938 |
-| Text               |        97,662 |      *18,960* |        22,473 |        21,752 |
-| Pixels             |     1,365,211 |     *903,549* |       867,702 |       775,781 |
-| Lines              |     1,062,311 |     *412,026* |       269,060 |       264,950 |
-| Horiz/Vert Lines   |        17,637 |      *14,197* |        13,692 |        13,833 |
-| Rectangles-filled  |       406,817 |     *332,696* |       320,761 |       323,908 |
-| Rectangles         |        11,641 |       *9,254* |         8,545 |         8,714 |
-| Triangles-filled   |       150,941 |     *118,010* |       105,661 |       109,675 |
-| Triangles          |        58,843 |      *23,570* |        15,884 |        16,277 |
-| Circles-filled     |        76,739 |      *52,170* |        42,787 |        45,827 |
-| Circles            |       118,125 |      *40,955* |        25,959 |        25,269 |
-| Arcs-filled        |      N/A      |      *33,381* |        21,546 |      N/A      |
-| Arcs               |      N/A      |      *66,054* |        47,901 |      N/A      |
-| Rounded rects-fill |       408,534 |     *338,136* |       318,882 |       323,189 |
-| Rounded rects      |        43,185 |      *21,562* |        13,089 |        15,371 |
+| Benchmark          | Adafruit_GFX | *Arduino_GFX* | Lovyan_GFX | TFT_eSPI |
+|--------------------|--------------|-------------|------------|----------|
+| Screen fill        | 195,782      | *160,094*     | 154,341    | 155,938  |
+| Text               | 97,662       | *18,960*      | 22,473     | 21,752   |
+| Pixels             | 1,365,211    | *903,549*     | 867,702    | 775,781  |
+| Lines              | 1,062,311    | *412,026*     | 269,060    | 264,950  |
+| Horiz/Vert Lines   | 17,637       | *14,197*      | 13,692     | 13,833   |
+| Rectangles-filled  | 406,817      | *332,696*     | 320,761    | 323,908  |
+| Rectangles         | 11,641       | *9,254*       | 8,545      | 8,714    |
+| Triangles-filled   | 150,941      | *118,010*     | 105,661    | 109,675  |
+| Triangles          | 58,843       | *23,570*      | 15,884     | 16,277   |
+| Circles-filled     | 76,739       | *52,170*      | 42,787     | 45,827   |
+| Circles            | 118,125      | *40,955*      | 25,959     | 25,269   |
+| Arcs-filled        | N/A          | *33,381*      | 21,546     | N/A      |
+| Arcs               | N/A          | *66,054*      | 47,901     | N/A      |
+| Rounded rects-fill | 408,534      | *338,136*     | 318,882    | 323,189  |
+| Rounded rects      | 43,185       | *21,562*      | 13,089     | 15,371   |
 
 ### Why Run Fast?
 
@@ -332,14 +327,14 @@ ESP32LCD8, ESP32LCD16 and ESP32RGBPanel only supported by arduino-esp32 v2.x and
 * ESP32S3-2.1-TP
 * [ESPboy](https://www.espboy.com) [[demo video](https://youtu.be/Cx82XWrc8-0)]
 * [LILYGO T-Deck](https://www.lilygo.cc/products/t-deck) [[demo video](https://youtube.com/shorts/fXKTVqjUoPM)]
-* [LILYGO T-Display](https://www.lilygo.cc/products/lilygo®-ttgo-t-display-1-14-inch-lcd-esp32-control-board)
+* [LILYGO T-Display](https://www.lilygo.cc/products/lilygo%C2%AE-ttgo-t-display-1-14-inch-lcd-esp32-control-board)
 * [LILYGO T-Display-S3](https://www.lilygo.cc/products/t-display-s3) [[demo video](https://youtu.be/kpRC64QNQAo)]
 * [LILYGO T-Display-S3 AMOLED](https://www.lilygo.cc/products/t-display-s3-amoled) [[demo video](https://youtu.be/NvOGJAMlh1M)]
 * [T-Display S3 Long](https://www.lilygo.cc/products/t-display-s3-long)[[LVGL demo video](https://youtu.be/OuxLFwxvcVc)]
 * [LILYGO T-Display-s3-Pro](https://www.lilygo.cc/products/t-display-s3-pro) [[demo video](https://youtube.com/shorts/PE-GKTzbdP8)]
 * [LILYGO T-QT](https://www.lilygo.cc/products/t-qt-v1-1) [[demo video](https://youtube.com/shorts/V1MCQ1tQ8PM)]
 * [LILYGO T-RGB](https://www.lilygo.cc/products/t-rgb) [[LVGL demo video](https://youtu.be/BKEl_pWp_qQ)]
-* [LILYGO T-Track](https://www.lilygo.cc/products/t-track) [[demo video](https://youtu.be/6wmUhp-5eMg)][[LVGL demo video](https://youtu.be/wQjMu5JZSkg)]
+* [LILYGO T-Track](https://www.lilygo.cc/products/t-track) [[demo video](https://youtu.be/6wmUhp-5eMg)\]\[[LVGL demo video](https://youtu.be/wQjMu5JZSkg)]
 * [LILYGO T-Watch](http://www.lilygo.cn/prod_view.aspx?TypeId=50053&Id=1123)
 * [LILYGO T-Watch 2021](https://www.lilygo.cc/products/t-watch-2021)
 * [LILYGO T4 S3](https://www.lilygo.cc/products/t4-s3)[[LVGL demo video](https://youtu.be/h4vXEYrDERM)]
@@ -389,7 +384,7 @@ ESP32LCD8, ESP32LCD16 and ESP32RGBPanel only supported by arduino-esp32 v2.x and
 * ILI9486 320x480 (18 bit color) [[demo video](https://youtu.be/pZ6izDqmVds)]
 * ILI9488 320x480 (3 bit color with canvas) [[demo video](https://youtu.be/r7be0WbIBYk)]
 * ILI9488 320x480 (18 bit color) [[demo video](https://youtu.be/NkE-LhtLHBQ)]
-* ILI9806 (8-bit/16-bit Parallel) 480x854 [[demo video](https://youtu.be/mYv-wdtWr8s)] [[LVGL demo video](https://youtu.be/PqjV8lovg_c)][[2](https://youtu.be/j31KZoQUKis)]
+* ILI9806 (8-bit/16-bit Parallel) 480x854 [[demo video](https://youtu.be/mYv-wdtWr8s)] [[LVGL demo video](https://youtu.be/PqjV8lovg_c)\]\[[2](https://youtu.be/j31KZoQUKis)]
 * JBT6K71 240x320 (8-bit Parallel) [[demo video](https://youtu.be/qid3F4Gb0mM)]
 * NT35310 320x480 [[demo video](https://youtu.be/bvIz5CoYPNk)]
 * NT35510 480x800 (8-bit/16-bit Parallel) [[demo video](https://youtu.be/C_1ASzUN3bg)]

--- a/src/Arduino_DataBus.cpp
+++ b/src/Arduino_DataBus.cpp
@@ -133,20 +133,6 @@ void Arduino_DataBus::batchOperation(const uint8_t *operations, size_t len)
   }
 }
 
-#if defined(INCLUDE_READ_OPERATIONS)
-
-uint8_t Arduino_DataBus::receive(uint8_t commandByte, uint8_t index)
-{
-  return 0;
-}
-
-uint16_t Arduino_DataBus::receive16(uint16_t addr)
-{
-  return 0;
-}
-
-#endif // defined(INCLUDE_READ_OPERATIONS)
-
 #if !defined(LITTLE_FOOT_PRINT)
 void Arduino_DataBus::writePattern(uint8_t *data, uint8_t len, uint32_t repeat)
 {
@@ -207,5 +193,19 @@ void Arduino_DataBus::writeYCbCrPixels(uint8_t *yData, uint8_t *cbData, uint8_t 
     }
   }
 }
+
+#if defined(ARDUINO_GFX_INC_READ_OPERATIONS)
+
+uint8_t Arduino_DataBus::receive(uint8_t commandByte, uint8_t index)
+{
+  return 0;
+}
+
+uint16_t Arduino_DataBus::receive16(uint16_t addr)
+{
+  return 0;
+}
+
+#endif // defined(ARDUINO_GFX_INC_READ_OPERATIONS)
 
 #endif // !defined(LITTLE_FOOT_PRINT)

--- a/src/Arduino_DataBus.cpp
+++ b/src/Arduino_DataBus.cpp
@@ -133,6 +133,20 @@ void Arduino_DataBus::batchOperation(const uint8_t *operations, size_t len)
   }
 }
 
+#if defined(INCLUDE_READ_OPERATIONS)
+
+uint8_t Arduino_DataBus::receive(uint8_t commandByte, uint8_t index)
+{
+  return 0;
+}
+
+uint16_t Arduino_DataBus::receive16(uint16_t addr)
+{
+  return 0;
+}
+
+#endif // defined(INCLUDE_READ_OPERATIONS)
+
 #if !defined(LITTLE_FOOT_PRINT)
 void Arduino_DataBus::writePattern(uint8_t *data, uint8_t len, uint32_t repeat)
 {

--- a/src/Arduino_DataBus.h
+++ b/src/Arduino_DataBus.h
@@ -7,6 +7,8 @@
 
 #include <Arduino.h>
 
+#define INCLUDE_READ_OPERATIONS 1
+
 #include "YCbCr2RGB.h"
 
 #define GFX_SKIP_OUTPUT_BEGIN -2
@@ -297,6 +299,11 @@ public:
 #else
   void batchOperation(const uint8_t *operations, size_t len);
 #endif // !defined(LITTLE_FOOT_PRINT)
+
+#if defined(INCLUDE_READ_OPERATIONS)
+  virtual uint8_t receive(uint8_t commandByte, uint8_t index = 1);
+  virtual uint16_t receive16(uint16_t addr);
+#endif // defined(INCLUDE_READ_OPERATIONS)
 
 protected:
   int32_t _speed;

--- a/src/Arduino_DataBus.h
+++ b/src/Arduino_DataBus.h
@@ -7,8 +7,6 @@
 
 #include <Arduino.h>
 
-#define INCLUDE_READ_OPERATIONS 1
-
 #include "YCbCr2RGB.h"
 
 #define GFX_SKIP_OUTPUT_BEGIN -2
@@ -300,10 +298,10 @@ public:
   void batchOperation(const uint8_t *operations, size_t len);
 #endif // !defined(LITTLE_FOOT_PRINT)
 
-#if defined(INCLUDE_READ_OPERATIONS)
+#if defined(ARDUINO_GFX_INC_READ_OPERATIONS)
   virtual uint8_t receive(uint8_t commandByte, uint8_t index = 1);
   virtual uint16_t receive16(uint16_t addr);
-#endif // defined(INCLUDE_READ_OPERATIONS)
+#endif // defined(ARDUINO_GFX_INC_READ_OPERATIONS)
 
 protected:
   int32_t _speed;

--- a/src/Arduino_GFX.cpp
+++ b/src/Arduino_GFX.cpp
@@ -2266,7 +2266,7 @@ size_t Arduino_GFX::write(uint8_t c)
     else if (c != '\r') // Not a carriage return; is normal char
     {
       uint16_t first = pgm_read_word(&gfxFont->first),
-              last = pgm_read_word(&gfxFont->last);
+               last = pgm_read_word(&gfxFont->last);
       if ((c >= first) && (c <= last)) // Char present in this font?
       {
         GFXglyph *glyph = pgm_read_glyph_ptr(gfxFont, c - first);
@@ -2883,19 +2883,17 @@ void Arduino_GFX::charBounds(char c, int16_t *x, int16_t *y,
 /**************************************************************************/
 /*!
   @brief  Helper to determine size of a string with current font/size. Pass string and a cursor position, returns UL corner and W,H.
-  @param  str  The ascii string to measure
-  @param  x    The current cursor X
-  @param  y    The current cursor Y
-  @param  x1   The boundary X coordinate, set by function
-  @param  y1   The boundary Y coordinate, set by function
-  @param  w    The boundary width, set by function
-  @param  h    The boundary height, set by function
-  @param  clip Whether to limit the result to the screen size (default is true)
+  @param  str The ascii string to measure
+  @param  x   The current cursor X
+  @param  y   The current cursor Y
+  @param  x1  The boundary X coordinate, set by function
+  @param  y1  The boundary Y coordinate, set by function
+  @param  w   The boundary width, set by function
+  @param  h   The boundary height, set by function
 */
 /**************************************************************************/
 void Arduino_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
-                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h,
-                                bool clip)
+                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h)
 {
   uint8_t c; // Current character
 
@@ -2903,66 +2901,60 @@ void Arduino_GFX::getTextBounds(const char *str, int16_t x, int16_t y,
   *y1 = y;
   *w = *h = 0;
 
-  int16_t minx = _width, miny = _height, maxx = -1, maxy = -1;
+  int16_t minx = _max_text_x, miny = _max_text_y, maxx = _min_text_x, maxy = _min_text_y;
 
   while ((c = *str++))
   {
     charBounds(c, &x, &y, &minx, &miny, &maxx, &maxy);
   }
 
-  if (clip) {
-    if (maxx >= minx)
-    {
-      *x1 = minx;
-      *w = maxx - minx + 1;
-    }
-    if (maxy >= miny)
-    {
-      *y1 = miny;
-      *h = maxy - miny + 1;
-    }
+  if (maxx >= minx)
+  {
+    *x1 = minx;
+    *w = maxx - minx + 1;
+  }
+  if (maxy >= miny)
+  {
+    *y1 = miny;
+    *h = maxy - miny + 1;
   }
 }
 
 /**************************************************************************/
 /*!
   @brief  Helper to determine size of a string with current font/size. Pass string and a cursor position, returns UL corner and W,H.
-  @param  str  The ascii string to measure (as an arduino String() class)
-  @param  x    The current cursor X
-  @param  y    The current cursor Y
-  @param  x1   The boundary X coordinate, set by function
-  @param  y1   The boundary Y coordinate, set by function
-  @param  w    The boundary width, set by function
-  @param  h    The boundary height, set by function
-  @param  clip Whether to limit the result to the screen size (default is true)
+  @param  str The ascii string to measure (as an arduino String() class)
+  @param  x   The current cursor X
+  @param  y   The current cursor Y
+  @param  x1  The boundary X coordinate, set by function
+  @param  y1  The boundary Y coordinate, set by function
+  @param  w   The boundary width, set by function
+  @param  h   The boundary height, set by function
 */
 /**************************************************************************/
 void Arduino_GFX::getTextBounds(const String &str, int16_t x, int16_t y,
-                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h,
-                                bool clip)
+                                int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h)
 {
   if (str.length() != 0)
   {
-    getTextBounds(const_cast<char *>(str.c_str()), x, y, x1, y1, w, h, clip);
+    getTextBounds(const_cast<char *>(str.c_str()), x, y, x1, y1, w, h);
   }
 }
 
 /**************************************************************************/
 /*!
   @brief  Helper to determine size of a PROGMEM string with current font/size. Pass string and a cursor position, returns UL corner and W,H.
-  @param  str  The flash-memory ascii string to measure
-  @param  x    The current cursor X
-  @param  y    The current cursor Y
-  @param  x1   The boundary X coordinate, set by function
-  @param  y1   The boundary Y coordinate, set by function
-  @param  w    The boundary width, set by function
-  @param  h    The boundary height, set by function
-  @param  clip Whether to limit the result to the screen size (default is true)
+  @param  str The flash-memory ascii string to measure
+  @param  x   The current cursor X
+  @param  y   The current cursor Y
+  @param  x1  The boundary X coordinate, set by function
+  @param  y1  The boundary Y coordinate, set by function
+  @param  w   The boundary width, set by function
+  @param  h   The boundary height, set by function
 */
 /**************************************************************************/
 void Arduino_GFX::getTextBounds(const __FlashStringHelper *str,
-                                int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h,
-                                bool clip)
+                                int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h)
 {
   uint8_t *s = (uint8_t *)str, c;
 
@@ -2970,22 +2962,20 @@ void Arduino_GFX::getTextBounds(const __FlashStringHelper *str,
   *y1 = y;
   *w = *h = 0;
 
-  int16_t minx = _width, miny = _height, maxx = -1, maxy = -1;
+  int16_t minx = _max_text_x, miny = _max_text_y, maxx = _min_text_x, maxy = _min_text_y;
 
   while ((c = pgm_read_byte(s++)))
     charBounds(c, &x, &y, &minx, &miny, &maxx, &maxy);
 
-  if (clip) {
-    if (maxx >= minx)
-    {
-      *x1 = minx;
-      *w = maxx - minx + 1;
-    }
-    if (maxy >= miny)
-    {
-      *y1 = miny;
-      *h = maxy - miny + 1;
-    }
+  if (maxx >= minx)
+  {
+    *x1 = minx;
+    *w = maxx - minx + 1;
+  }
+  if (maxy >= miny)
+  {
+    *y1 = miny;
+    *h = maxy - miny + 1;
   }
 }
 

--- a/src/Arduino_GFX.h
+++ b/src/Arduino_GFX.h
@@ -29,7 +29,7 @@
 #include "font/u8g2_font_unifont_t_cjk.h"
 #endif
 
-#define RGB565(r, g, b) ((((r)&0xF8) << 8) | (((g)&0xFC) << 3) | ((b) >> 3))
+#define RGB565(r, g, b) ((((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3))
 #define RGB16TO24(c) ((((uint32_t)c & 0xF800) << 8) | ((c & 0x07E0) << 5) | ((c & 0x1F) << 3))
 
 #define RGB565_BLACK RGB565(0, 0, 0)
@@ -199,35 +199,35 @@ public:
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
   // It's good to implement those, even if using transaction API
-  void writePixel(int16_t x, int16_t y, uint16_t color);
-  void drawPixel(int16_t x, int16_t y, uint16_t color);
-  void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-  void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
-  void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
-  void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
-  void fillScreen(uint16_t color);
+  virtual void writePixel(int16_t x, int16_t y, uint16_t color);
+  virtual void drawPixel(int16_t x, int16_t y, uint16_t color);
+  virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void fillScreen(uint16_t color);
   virtual void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color);
-  void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
   virtual void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
-  void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
-  void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
-  void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
-  void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius, uint16_t color);
-  void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius, uint16_t color);
-  void drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color);
-  void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color);
-  void drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color);
-  void drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
-  void drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
-  void draw16bitRGBBitmapWithMask(int16_t x, int16_t y, const uint16_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
-  void draw24bitRGBBitmap(int16_t x, int16_t y, const uint8_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
-  void draw24bitRGBBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
-  void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
-  void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
-  void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
-  void setTextSize(uint8_t s);
-  void setTextSize(uint8_t sx, uint8_t sy);
-  void setTextSize(uint8_t sx, uint8_t sy, uint8_t pixel_margin);
+  virtual void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  virtual void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
+  virtual void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
+  virtual void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius, uint16_t color);
+  virtual void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius, uint16_t color);
+  virtual void drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color);
+  virtual void drawBitmap(int16_t x, int16_t y, uint8_t *bitmap, int16_t w, int16_t h, uint16_t color);
+  virtual void drawXBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color);
+  virtual void drawGrayscaleBitmap(int16_t x, int16_t y, const uint8_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
+  virtual void drawGrayscaleBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
+  virtual void draw16bitRGBBitmapWithMask(int16_t x, int16_t y, const uint16_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
+  virtual void draw24bitRGBBitmap(int16_t x, int16_t y, const uint8_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
+  virtual void draw24bitRGBBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
+  virtual void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  virtual void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  virtual void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  virtual void setTextSize(uint8_t s);
+  virtual void setTextSize(uint8_t sx, uint8_t sy);
+  virtual void setTextSize(uint8_t sx, uint8_t sy, uint8_t pixel_margin);
 
 #if !defined(ATTINY_CORE)
   void setFont(const GFXfont *f = NULL);
@@ -243,13 +243,13 @@ public:
 #endif // !defined(ATTINY_CORE)
 
   // adopt from LovyanGFX
-  void drawEllipse(int16_t x, int16_t y, int16_t rx, int16_t ry, uint16_t color);
-  void writeEllipseHelper(int32_t x, int32_t y, int32_t rx, int32_t ry, uint8_t cornername, uint16_t color);
-  void fillEllipse(int16_t x, int16_t y, int16_t rx, int16_t ry, uint16_t color);
-  void writeFillEllipseHelper(int32_t x, int32_t y, int32_t rx, int32_t ry, uint8_t cornername, int16_t delta, uint16_t color);
-  void drawArc(int16_t x, int16_t y, int16_t r1, int16_t r2, float start, float end, uint16_t color);
-  void fillArc(int16_t x, int16_t y, int16_t r1, int16_t r2, float start, float end, uint16_t color);
-  void writeFillArcHelper(int16_t cx, int16_t cy, int16_t oradius, int16_t iradius, float start, float end, uint16_t color);
+  virtual void drawEllipse(int16_t x, int16_t y, int16_t rx, int16_t ry, uint16_t color);
+  virtual void writeEllipseHelper(int32_t x, int32_t y, int32_t rx, int32_t ry, uint8_t cornername, uint16_t color);
+  virtual void fillEllipse(int16_t x, int16_t y, int16_t rx, int16_t ry, uint16_t color);
+  virtual void writeFillEllipseHelper(int32_t x, int32_t y, int32_t rx, int32_t ry, uint8_t cornername, int16_t delta, uint16_t color);
+  virtual void drawArc(int16_t x, int16_t y, int16_t r1, int16_t r2, float start, float end, uint16_t color);
+  virtual void fillArc(int16_t x, int16_t y, int16_t r1, int16_t r2, float start, float end, uint16_t color);
+  virtual void writeFillArcHelper(int16_t cx, int16_t cy, int16_t oradius, int16_t iradius, float start, float end, uint16_t color);
 
 // TFT optimization code, too big for ATMEL family
 #if defined(LITTLE_FOOT_PRINT)
@@ -309,18 +309,10 @@ public:
   */
   void setTextBound(int16_t x, int16_t y, int16_t w, int16_t h)
   {
-    _min_text_x = (x < 0) ? 0 : x;
-    _min_text_y = (y < 0) ? 0 : y;
+    _min_text_x = x;
+    _min_text_y = y;
     _max_text_x = x + w - 1;
-    if (_max_text_x > _max_x)
-    {
-      _max_text_x = _max_x;
-    }
     _max_text_y = y + h - 1;
-    if (_max_text_y > _max_y)
-    {
-      _max_text_y = _max_y;
-    }
   }
 
   /**********************************************************************/

--- a/src/Arduino_GFX.h
+++ b/src/Arduino_GFX.h
@@ -29,7 +29,7 @@
 #include "font/u8g2_font_unifont_t_cjk.h"
 #endif
 
-#define RGB565(r, g, b) ((((r) & 0xF8) << 8) | (((g) & 0xFC) << 3) | ((b) >> 3))
+#define RGB565(r, g, b) ((((r)&0xF8) << 8) | (((g)&0xFC) << 3) | ((b) >> 3))
 #define RGB16TO24(c) ((((uint32_t)c & 0xF800) << 8) | ((c & 0x07E0) << 5) | ((c & 0x1F) << 3))
 
 #define RGB565_BLACK RGB565(0, 0, 0)
@@ -206,9 +206,9 @@ public:
   void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
   void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
   void fillScreen(uint16_t color);
-  void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color);
+  virtual void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color);
   void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
-  void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  virtual void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
   void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
   void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
   void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
@@ -222,9 +222,9 @@ public:
   void draw16bitRGBBitmapWithMask(int16_t x, int16_t y, const uint16_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
   void draw24bitRGBBitmap(int16_t x, int16_t y, const uint8_t bitmap[], const uint8_t mask[], int16_t w, int16_t h);
   void draw24bitRGBBitmap(int16_t x, int16_t y, uint8_t *bitmap, uint8_t *mask, int16_t w, int16_t h);
-  void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
-  void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
-  void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
+  void getTextBounds(const char *string, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
+  void getTextBounds(const __FlashStringHelper *s, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
+  void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h, bool clip = true);
   void setTextSize(uint8_t s);
   void setTextSize(uint8_t sx, uint8_t sy);
   void setTextSize(uint8_t sx, uint8_t sy, uint8_t pixel_margin);
@@ -309,10 +309,18 @@ public:
   */
   void setTextBound(int16_t x, int16_t y, int16_t w, int16_t h)
   {
-    _min_text_x = x;
-    _min_text_y = y;
+    _min_text_x = (x < 0) ? 0 : x;
+    _min_text_y = (y < 0) ? 0 : y;
     _max_text_x = x + w - 1;
+    if (_max_text_x > _max_x)
+    {
+      _max_text_x = _max_x;
+    }
     _max_text_y = y + h - 1;
+    if (_max_text_y > _max_y)
+    {
+      _max_text_y = _max_y;
+    }
   }
 
   /**********************************************************************/

--- a/src/Arduino_GFX_Library.h
+++ b/src/Arduino_GFX_Library.h
@@ -38,6 +38,7 @@
 #include "databus/Arduino_Wire.h"
 #include "databus/Arduino_XL9535SWSPI.h"
 #include "databus/Arduino_XCA9554SWSPI.h"
+#include "databus/Arduino_HWSPI_NoDC.h"
 
 #include "Arduino_GFX.h" // Core graphics library
 #if !defined(LITTLE_FOOT_PRINT)

--- a/src/databus/Arduino_HWSPI_NoDC.cpp
+++ b/src/databus/Arduino_HWSPI_NoDC.cpp
@@ -1,0 +1,479 @@
+/*
+ * start rewrite from:
+ * https://github.com/adafruit/Adafruit-GFX-Library.git
+ */
+#include "Arduino_HWSPI_NoDC.h"
+
+#if defined(SPI_HAS_TRANSACTION)
+#define SPI_BEGIN_TRANSACTION() _spi->beginTransaction(mySPISettings)
+#define SPI_END_TRANSACTION() _spi->endTransaction()
+#else
+#define SPI_BEGIN_TRANSACTION() \
+  {                             \
+  }
+#define SPI_END_TRANSACTION() \
+  {                           \
+  }
+#endif
+
+#if defined(SPI_HAS_TRANSACTION)
+static SPISettings mySPISettings;
+#elif defined(__AVR__) || defined(CORE_TEENSY)
+static uint8_t SPCRbackup;
+static uint8_t mySPCR;
+#endif
+
+#if defined(ESP32)
+Arduino_HWSPI_NoDC::Arduino_HWSPI_NoDC(int8_t cs /* = GFX_NOT_DEFINED */, int8_t sck /* = GFX_NOT_DEFINED */, int8_t mosi /* = GFX_NOT_DEFINED */, int8_t miso /* = GFX_NOT_DEFINED */, SPIClass *spi, bool is_shared_interface /* = true */, uint16_t commandValue, uint16_t dataValue)
+    : _cs(cs), _sck(sck), _mosi(mosi), _miso(miso), _spi(spi), _is_shared_interface(is_shared_interface), _commandValue(commandValue), _dataValue(dataValue)
+{
+#else
+Arduino_HWSPI_NoDC::Arduino_HWSPI_NoDC(int8_t cs /* = GFX_NOT_DEFINED */, SPIClass *spi, bool is_shared_interface /* = true */, uint16_t commandValue, uint16_t dataValue, uint16_t readValue, uint16_t writeValue)
+    : _cs(cs), _spi(spi), _is_shared_interface(is_shared_interface), _commandValue(commandValue), _dataValue(dataValue), _readValue(readValue), _writeValue(writeValue)
+{
+#endif
+}
+
+bool Arduino_HWSPI_NoDC::begin(int32_t speed, int8_t dataMode)
+{
+  _speed = (speed == GFX_NOT_DEFINED) ? SPI_DEFAULT_FREQ : speed;
+  _dataMode = dataMode;
+
+  if (_cs != GFX_NOT_DEFINED)
+  {
+    pinMode(_cs, OUTPUT);
+    digitalWrite(_cs, HIGH); // Deselect
+  }
+
+#if defined(USE_FAST_PINIO)
+#if defined(HAS_PORT_SET_CLR)
+#if defined(ARDUINO_ARCH_NRF52840)
+  if (_cs != GFX_NOT_DEFINED)
+  {
+    uint32_t pin = digitalPinToPinName((pin_size_t)_cs);
+    NRF_GPIO_Type *reg = nrf_gpio_pin_port_decode(&pin);
+    _csPortSet = &reg->OUTSET;
+    _csPortClr = &reg->OUTCLR;
+    _csPinMask = 1UL << pin;
+  }
+#elif defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI)
+  if (_cs != GFX_NOT_DEFINED)
+  {
+    _csPinMask = digitalPinToBitMask(_cs);
+    _csPortSet = (PORTreg_t) & (((R_PORT0_Type *)IOPORT_PRV_PORT_ADDRESS(digitalPinToPort(_cs)))->POSR);
+    _csPortClr = (PORTreg_t) & (((R_PORT0_Type *)IOPORT_PRV_PORT_ADDRESS(digitalPinToPort(_cs)))->PORR);
+  }
+#elif defined(TARGET_RP2040)
+  if (_cs != GFX_NOT_DEFINED)
+  {
+    _csPinMask = digitalPinToBitMask(_cs);
+    _csPortSet = (PORTreg_t)&sio_hw->gpio_set;
+    _csPortClr = (PORTreg_t)&sio_hw->gpio_clr;
+  }
+#elif defined(ESP32) && (CONFIG_IDF_TARGET_ESP32C3)
+  if (_cs != GFX_NOT_DEFINED)
+  {
+    _csPinMask = digitalPinToBitMask(_cs);
+    _csPortSet = (PORTreg_t)GPIO_OUT_W1TS_REG;
+    _csPortClr = (PORTreg_t)GPIO_OUT_W1TC_REG;
+  }
+#elif defined(ESP32)
+  if (_cs >= 32)
+  {
+    _csPinMask = digitalPinToBitMask(_cs);
+    _csPortSet = (PORTreg_t)GPIO_OUT1_W1TS_REG;
+    _csPortClr = (PORTreg_t)GPIO_OUT1_W1TC_REG;
+  }
+  else if (_cs != GFX_NOT_DEFINED)
+  {
+    _csPinMask = digitalPinToBitMask(_cs);
+    _csPortSet = (PORTreg_t)GPIO_OUT_W1TS_REG;
+    _csPortClr = (PORTreg_t)GPIO_OUT_W1TC_REG;
+  }
+#elif defined(CORE_TEENSY)
+  if (_cs != GFX_NOT_DEFINED)
+  {
+#if !defined(KINETISK)
+    _csPinMask = digitalPinToBitMask(_cs);
+#endif
+    _csPortSet = portSetRegister(_cs);
+    _csPortClr = portClearRegister(_cs);
+  }
+#else  // !CORE_TEENSY
+  if (_cs != GFX_NOT_DEFINED)
+  {
+    _csPinMask = digitalPinToBitMask(_cs);
+    _csPortSet = &(PORT->Group[g_APinDescription[_cs].ulPort].OUTSET.reg);
+    _csPortClr = &(PORT->Group[g_APinDescription[_cs].ulPort].OUTCLR.reg);
+  }
+#endif // end !CORE_TEENSY
+#else  // !HAS_PORT_SET_CLR
+  if (_cs != GFX_NOT_DEFINED)
+  {
+    _csPort = (PORTreg_t)portOutputRegister(digitalPinToPort(_cs));
+    _csPinMaskSet = digitalPinToBitMask(_cs);
+  }
+  _csPinMaskClr = ~_csPinMaskSet;
+#endif // !HAS_PORT_SET_CLR
+#endif // USE_FAST_PINIO
+
+#if defined(ESP32)
+  _spi->begin(_sck, _miso, _mosi);
+  if (_dataMode == GFX_NOT_DEFINED)
+  {
+    _dataMode = SPI_MODE0;
+  }
+  mySPISettings = SPISettings(_speed, MSBFIRST, _dataMode);
+#elif defined(ESP8266)
+  _spi->begin();
+  if (_dataMode == GFX_NOT_DEFINED)
+  {
+    _dataMode = SPI_MODE0;
+  }
+  mySPISettings = SPISettings(_speed, MSBFIRST, _dataMode);
+// Teensy 4.x
+#elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
+  _spi->begin();
+  if (_dataMode == GFX_NOT_DEFINED)
+  {
+    _dataMode = SPI_MODE0;
+  }
+  mySPISettings = SPISettings(_speed, MSBFIRST, _dataMode);
+#elif defined(SPI_HAS_TRANSACTION)
+  _spi->begin();
+  if (_dataMode == GFX_NOT_DEFINED)
+  {
+    _dataMode = SPI_MODE2;
+  }
+  mySPISettings = SPISettings(_speed, MSBFIRST, _dataMode);
+#elif defined(__AVR__) || defined(CORE_TEENSY)
+  SPCRbackup = SPCR;
+  _spi->begin();
+  _spi->setClockDivider(SPI_CLOCK_DIV2);
+  if (_dataMode == GFX_NOT_DEFINED)
+  {
+    _dataMode = SPI_MODE2;
+  }
+  _spi->setDataMode(_dataMode);
+  mySPCR = SPCR;     // save our preferred state
+  SPCR = SPCRbackup; // then restore
+#elif defined(__SAM3X8E__)
+  _spi->begin();
+  _spi->setClockDivider(21); // 4MHz
+  if (_dataMode == GFX_NOT_DEFINED)
+  {
+    _dataMode = SPI_MODE2;
+  }
+  _spi->setDataMode(_dataMode);
+#elif defined(__arm__)
+  if (_dataMode == GFX_NOT_DEFINED)
+  {
+    _dataMode = SPI_MODE2;
+  }
+#endif
+
+  return true;
+}
+
+void Arduino_HWSPI_NoDC::beginWrite()
+{
+  if (_is_shared_interface)
+  {
+    SPI_BEGIN_TRANSACTION();
+  }
+
+  CS_LOW();
+}
+
+void Arduino_HWSPI_NoDC::endWrite()
+{
+  CS_HIGH();
+
+  if (_is_shared_interface)
+  {
+    SPI_END_TRANSACTION();
+  }
+}
+
+void Arduino_HWSPI_NoDC::writeCommand(uint8_t c)
+{
+  beginWrite();
+  WRITE16(_commandValue | _writeValue | c);
+  endWrite();
+}
+
+void Arduino_HWSPI_NoDC::writeCommand16(uint16_t c)
+{
+#if defined(LITTLE_FOOT_PRINT)
+  _data16.value = c;
+  WRITE16(_commandValue | _writeValue | _data16.msb);
+  WRITE16(_commandValue | _writeValue | _data16.lsb);
+#else  // !defined(LITTLE_FOOT_PRINT)
+  beginWrite();
+  WRITE16(_commandValue | _writeValue | c);
+  endWrite();
+#endif // !defined(LITTLE_FOOT_PRINT)
+}
+
+void Arduino_HWSPI_NoDC::writeCommandBytes(uint8_t *data, uint32_t len)
+{
+  beginWrite();
+  while (len--)
+  {
+    WRITE16(_commandValue | _writeValue | (*data++));
+  }
+  endWrite();
+}
+
+void Arduino_HWSPI_NoDC::write(uint8_t d)
+{
+  beginWrite();
+  WRITE16(_dataValue | _writeValue | d);
+  endWrite();
+}
+
+void Arduino_HWSPI_NoDC::write16(uint16_t d)
+{
+#if defined(LITTLE_FOOT_PRINT)
+  _data16.value = d;
+  WRITE16(_dataValue | _writeValue | _data16.msb);
+  WRITE16(_dataValue | _writeValue | _data16.lsb);
+#else  // !defined(LITTLE_FOOT_PRINT)
+  beginWrite();
+  WRITE16(_dataValue | _writeValue | d);
+  endWrite();
+#endif // !defined(LITTLE_FOOT_PRINT)
+}
+
+void Arduino_HWSPI_NoDC::writeRepeat(uint16_t p, uint32_t len)
+{
+#if defined(LITTLE_FOOT_PRINT)
+  _data16.value = p;
+  while (len--)
+  {
+    WRITE16(_dataValue | _writeValue | _data16.msb);
+    WRITE16(_dataValue | _writeValue | _data16.lsb);
+  }
+#elif defined(ESP8266) || defined(CONFIG_ARCH_CHIP_CXD56XX)
+  MSB_16_SET(p, p);
+  uint32_t xferLen = (len < SPI_MAX_PIXELS_AT_ONCE) ? len : SPI_MAX_PIXELS_AT_ONCE;
+  for (uint32_t i = 0; i < xferLen; i++)
+  {
+    _buffer.v16[i] = p;
+  }
+
+  while (len)
+  {
+    xferLen = (len < SPI_MAX_PIXELS_AT_ONCE) ? len : SPI_MAX_PIXELS_AT_ONCE;
+    len -= xferLen;
+
+    xferLen += xferLen;
+    WRITEBUF(_buffer.v8, xferLen);
+  }
+#else  // other arch
+  MSB_16_SET(p, p);
+  uint32_t xferLen;
+
+  beginWrite();
+  while (len)
+  {
+    xferLen = (len < SPI_MAX_PIXELS_AT_ONCE) ? len : SPI_MAX_PIXELS_AT_ONCE;
+    for (uint32_t i = 0; i < xferLen; i++)
+    {
+      _buffer.v16[i] = p;
+    }
+    len -= xferLen;
+
+    xferLen += xferLen;
+    WRITEBUF(_buffer.v8, xferLen);
+  }
+  endWrite();
+#endif // other arch
+}
+
+void Arduino_HWSPI_NoDC::writeBytes(uint8_t *data, uint32_t len)
+{
+#if defined(LITTLE_FOOT_PRINT)
+  while (len--)
+  {
+    WRITE(*data++);
+  }
+#else  // !defined(LITTLE_FOOT_PRINT)
+  beginWrite();
+  WRITEBUF(data, len);
+  endWrite();
+#endif // !defined(LITTLE_FOOT_PRINT)
+}
+
+void Arduino_HWSPI_NoDC::writePixels(uint16_t *data, uint32_t len)
+{
+#if defined(LITTLE_FOOT_PRINT)
+  while (len--)
+  {
+    _data16.value = *data++;
+    WRITE(_data16.msb);
+    WRITE(_data16.lsb);
+  }
+#else  // !defined(LITTLE_FOOT_PRINT)
+  uint32_t xferLen;
+  uint8_t *b;
+  union
+  {
+    uint16_t val;
+    struct
+    {
+      uint8_t lsb;
+      uint8_t msb;
+    };
+  } t;
+
+  beginWrite();
+  while (len)
+  {
+    xferLen = (len < SPI_MAX_PIXELS_AT_ONCE) ? len : SPI_MAX_PIXELS_AT_ONCE;
+    b = _buffer.v8;
+    for (uint32_t i = 0; i < xferLen; i++)
+    {
+      t.val = *data++;
+      *b++ = t.msb;
+      *b++ = t.lsb;
+    }
+    len -= xferLen;
+
+    xferLen += xferLen; // uint16_t to uint8_t, double length
+    WRITEBUF(_buffer.v8, xferLen);
+  }
+  endWrite();
+#endif // !defined(LITTLE_FOOT_PRINT)
+}
+
+#if !defined(LITTLE_FOOT_PRINT)
+void Arduino_HWSPI_NoDC::writePattern(uint8_t *data, uint8_t len, uint32_t repeat)
+{
+#if defined(ESP8266) || defined(ESP32)
+  _spi->writePattern(data, len, repeat);
+#else  // !(defined(ESP8266) || defined(ESP32))
+  beginWrite();
+  while (repeat--)
+  {
+    WRITEBUF(data, len);
+  }
+  endWrite();
+#endif // !(defined(ESP8266) || defined(ESP32))
+}
+
+
+#endif // !defined(LITTLE_FOOT_PRINT)
+
+#if defined(INCLUDE_READ_OPERATIONS)
+
+uint8_t Arduino_HWSPI_NoDC::receive(uint8_t commandByte, uint8_t index)
+{
+    uint8_t result;
+    beginWrite();
+
+    result=WRITE16(_commandValue | _writeValue | commandByte);
+    while(index>0) {
+      result = WRITE16(_dataValue | _readValue);
+      index--;
+    } // Discard bytes up to index'th byte
+    endWrite();
+
+    return result;
+}
+
+uint16_t Arduino_HWSPI_NoDC::receive16(uint16_t addr)
+{
+    beginWrite();
+    uint16_t val = WRITE16(addr);
+    endWrite();
+
+    return val;
+}
+
+
+#endif // defined(INCLUDE_READ_OPERATIONS)
+
+
+#if !defined(LITTLE_FOOT_PRINT)
+
+INLINE uint16_t Arduino_HWSPI_NoDC::WRITE16(uint16_t d)
+{
+#if defined(ESP8266) || defined(ESP32)
+  _spi->write16(d);
+#elif defined(SPI_HAS_TRANSACTION)
+  return _spi->transfer16(d);
+#elif defined(__AVR__) || defined(CORE_TEENSY)
+  SPCRbackup = SPCR;
+  SPCR = mySPCR;
+  uint16_t r = _spi->transfer16(d);
+  SPCR = SPCRbackup;
+  return r;
+#elif defined(__arm__)
+  _spi->setClockDivider(21); // 4MHz
+  _spi->setDataMode(_dataMode);
+  return _spi->transfer16(d);
+#else
+  return _spi->transfer16(d);
+#endif
+}
+
+INLINE void Arduino_HWSPI_NoDC::WRITEBUF(uint8_t *buf, size_t count)
+{
+  for(size_t i=0;i<count;i++)
+  {
+    uint16_t data = _dataValue | buf[i];
+#if defined(ESP8266) || defined(ESP32)
+    _spi->writeBytes(data);
+#elif defined(CONFIG_ARCH_CHIP_CXD56XX)
+    _spi->send(data);
+#else  // other arch.
+    _spi->transfer16(data);
+#endif // other arch.
+  }
+}
+
+#endif // !defined(LITTLE_FOOT_PRINT)
+
+/******** low level bit twiddling **********/
+
+
+INLINE void Arduino_HWSPI_NoDC::CS_HIGH(void)
+{
+  if (_cs != GFX_NOT_DEFINED)
+  {
+#if defined(USE_FAST_PINIO)
+#if defined(HAS_PORT_SET_CLR)
+#if defined(KINETISK)
+    *_csPortSet = 1;
+#else  // !KINETISK
+    *_csPortSet = _csPinMask;
+#endif // end !KINETISK
+#else  // !HAS_PORT_SET_CLR
+    *_csPort |= _csPinMaskSet;
+#endif // end !HAS_PORT_SET_CLR
+#else  // !USE_FAST_PINIO
+    digitalWrite(_cs, HIGH);
+#endif // end !USE_FAST_PINIO
+  }
+}
+
+INLINE void Arduino_HWSPI_NoDC::CS_LOW(void)
+{
+  if (_cs != GFX_NOT_DEFINED)
+  {
+#if defined(USE_FAST_PINIO)
+#if defined(HAS_PORT_SET_CLR)
+#if defined(KINETISK)
+    *_csPortClr = 1;
+#else  // !KINETISK
+    *_csPortClr = _csPinMask;
+#endif // end !KINETISK
+#else  // !HAS_PORT_SET_CLR
+    *_csPort &= _csPinMaskClr;
+#endif // end !HAS_PORT_SET_CLR
+#else  // !USE_FAST_PINIO
+    digitalWrite(_cs, LOW);
+#endif // end !USE_FAST_PINIO
+  }
+}

--- a/src/databus/Arduino_HWSPI_NoDC.cpp
+++ b/src/databus/Arduino_HWSPI_NoDC.cpp
@@ -365,7 +365,7 @@ void Arduino_HWSPI_NoDC::writePattern(uint8_t *data, uint8_t len, uint32_t repea
 
 #endif // !defined(LITTLE_FOOT_PRINT)
 
-#if defined(INCLUDE_READ_OPERATIONS)
+#if defined(ARDUINO_GFX_INC_READ_OPERATIONS)
 
 uint8_t Arduino_HWSPI_NoDC::receive(uint8_t commandByte, uint8_t index)
 {
@@ -392,12 +392,12 @@ uint16_t Arduino_HWSPI_NoDC::receive16(uint16_t addr)
 }
 
 
-#endif // defined(INCLUDE_READ_OPERATIONS)
+#endif // defined(ARDUINO_GFX_INC_READ_OPERATIONS)
 
 
 #if !defined(LITTLE_FOOT_PRINT)
 
-INLINE uint16_t Arduino_HWSPI_NoDC::WRITE16(uint16_t d)
+GFX_INLINE uint16_t Arduino_HWSPI_NoDC::WRITE16(uint16_t d)
 {
 #if defined(ESP8266) || defined(ESP32)
   _spi->write16(d);
@@ -418,7 +418,7 @@ INLINE uint16_t Arduino_HWSPI_NoDC::WRITE16(uint16_t d)
 #endif
 }
 
-INLINE void Arduino_HWSPI_NoDC::WRITEBUF(uint8_t *buf, size_t count)
+GFX_INLINE void Arduino_HWSPI_NoDC::WRITEBUF(uint8_t *buf, size_t count)
 {
   for(size_t i=0;i<count;i++)
   {
@@ -438,7 +438,7 @@ INLINE void Arduino_HWSPI_NoDC::WRITEBUF(uint8_t *buf, size_t count)
 /******** low level bit twiddling **********/
 
 
-INLINE void Arduino_HWSPI_NoDC::CS_HIGH(void)
+GFX_INLINE void Arduino_HWSPI_NoDC::CS_HIGH(void)
 {
   if (_cs != GFX_NOT_DEFINED)
   {
@@ -458,7 +458,7 @@ INLINE void Arduino_HWSPI_NoDC::CS_HIGH(void)
   }
 }
 
-INLINE void Arduino_HWSPI_NoDC::CS_LOW(void)
+GFX_INLINE void Arduino_HWSPI_NoDC::CS_LOW(void)
 {
   if (_cs != GFX_NOT_DEFINED)
   {

--- a/src/databus/Arduino_HWSPI_NoDC.h
+++ b/src/databus/Arduino_HWSPI_NoDC.h
@@ -1,0 +1,99 @@
+/*
+ * start rewrite from:
+ * https://github.com/adafruit/Adafruit-GFX-Library.git
+ */
+#ifndef _ARDUINO_HWSPI_NO_DC_H_
+#define _ARDUINO_HWSPI_NO_DC_H_
+
+#include <SPI.h>
+#include "Arduino_DataBus.h"
+
+#if !defined(LITTLE_FOOT_PRINT)
+#ifndef SPI_MAX_PIXELS_AT_ONCE
+#define SPI_MAX_PIXELS_AT_ONCE 32
+#endif
+#endif
+
+// HARDWARE CONFIG ---------------------------------------------------------
+
+class Arduino_HWSPI_NoDC : public Arduino_DataBus
+{
+public:
+#if defined(ESP32)
+  Arduino_HWSPI_NoDC(int8_t cs = GFX_NOT_DEFINED, int8_t sck = GFX_NOT_DEFINED, int8_t mosi = GFX_NOT_DEFINED, int8_t miso = GFX_NOT_DEFINED, SPIClass *spi = &SPI, bool is_shared_interface = true, uint16_t commandValue = 0x0000, uint16_t dataValue = 0x8000); // Constructor
+#elif defined(ARDUINO_ARCH_SAMD) && defined(SEEED_GROVE_UI_WIRELESS)
+  Arduino_HWSPI_NoDC(int8_t cs = GFX_NOT_DEFINED, SPIClass *spi = &LCD_SPI, bool is_shared_interface = true, uint16_t commandValue = 0x0000, uint16_t dataValue = 0x8000, uint16_t readValue = 0x4000, uint16_t writeValue= 0x0000); // Constructor
+#elif defined(RTL8722DM) && defined(BOARD_RTL8722DM)
+  Arduino_HWSPI_NoDC(int8_t cs = GFX_NOT_DEFINED, SPIClass *spi = &SPI1, bool is_shared_interface = true, uint16_t commandValue = 0x0000, uint16_t dataValue = 0x8000, uint16_t readValue = 0x4000, uint16_t writeValue= 0x0000); // Constructor
+#else
+  Arduino_HWSPI_NoDC(int8_t cs = GFX_NOT_DEFINED, SPIClass *spi = &SPI, bool is_shared_interface = true, uint16_t commandValue = 0x0000, uint16_t dataValue = 0x8000, uint16_t readValue = 0x4000, uint16_t writeValue= 0x0000); // Constructor
+#endif
+
+  bool begin(int32_t speed = GFX_NOT_DEFINED, int8_t dataMode = GFX_NOT_DEFINED) override;
+  void beginWrite() override;
+  void endWrite() override;
+  void writeCommand(uint8_t) override;
+  void writeCommand16(uint16_t) override;
+  void writeCommandBytes(uint8_t *data, uint32_t len) override;
+  void write(uint8_t) override;
+  void write16(uint16_t) override;
+  void writeRepeat(uint16_t p, uint32_t len) override;
+  void writeBytes(uint8_t *data, uint32_t len) override;
+  void writePixels(uint16_t *data, uint32_t len) override;
+
+#if !defined(LITTLE_FOOT_PRINT)
+  void writePattern(uint8_t *data, uint8_t len, uint32_t repeat) override;
+#endif // !defined(LITTLE_FOOT_PRINT)
+
+#if defined(INCLUDE_READ_OPERATIONS)
+  uint8_t receive(uint8_t commandByte, uint8_t index = 0) override;
+  uint16_t receive16(uint16_t addr) override;
+#endif
+
+private:
+  INLINE uint16_t WRITE16(uint16_t d);
+  INLINE void WRITEBUF(uint8_t *buf, size_t count);
+  INLINE void CS_HIGH(void);
+  INLINE void CS_LOW(void);
+
+
+  int8_t _cs;
+#if defined(ESP32)
+  int8_t _sck, _mosi, _miso;
+#endif
+  SPIClass *_spi;
+  bool _is_shared_interface;
+  uint16_t _commandValue, _dataValue, _readValue, _writeValue;
+
+  // CLASS INSTANCE VARIABLES --------------------------------------------
+
+  // Here be dragons! There's a big union of three structures here --
+  // one each for hardware SPI, software (bitbang) SPI, and parallel
+  // interfaces. This is to save some memory, since a display's connection
+  // will be only one of these. The order of some things is a little weird
+  // in an attempt to get values to align and pack better in RAM.
+
+#if defined(USE_FAST_PINIO)
+#if defined(HAS_PORT_SET_CLR)
+  PORTreg_t _csPortSet; ///< PORT register for chip select SET
+  PORTreg_t _csPortClr; ///< PORT register for chip select CLEAR
+#if !defined(KINETISK)
+  ARDUINOGFX_PORT_t _csPinMask; ///< Bitmask for chip select
+#endif                          // !KINETISK
+#else                           // !HAS_PORT_SET_CLR
+  PORTreg_t _csPort;               ///< PORT register for chip select
+  ARDUINOGFX_PORT_t _csPinMaskSet; ///< Bitmask for chip select SET (OR)
+  ARDUINOGFX_PORT_t _csPinMaskClr; ///< Bitmask for chip select CLEAR (AND)
+#endif                          // HAS_PORT_SET_CLR
+#endif                          // !defined(USE_FAST_PINIO)
+
+#if !defined(LITTLE_FOOT_PRINT)
+  union
+  {
+    uint8_t v8[SPI_MAX_PIXELS_AT_ONCE * 2] = {0};
+    uint16_t v16[SPI_MAX_PIXELS_AT_ONCE];
+  } _buffer;
+#endif // !defined(LITTLE_FOOT_PRINT)
+};
+
+#endif // _ARDUINO_HWSPI_H_

--- a/src/databus/Arduino_HWSPI_NoDC.h
+++ b/src/databus/Arduino_HWSPI_NoDC.h
@@ -45,16 +45,16 @@ public:
   void writePattern(uint8_t *data, uint8_t len, uint32_t repeat) override;
 #endif // !defined(LITTLE_FOOT_PRINT)
 
-#if defined(INCLUDE_READ_OPERATIONS)
+#if defined(ARDUINO_GFX_INC_READ_OPERATIONS)
   uint8_t receive(uint8_t commandByte, uint8_t index = 0) override;
   uint16_t receive16(uint16_t addr) override;
-#endif
+#endif // defined(ARDUINO_GFX_INC_READ_OPERATIONS)
 
 private:
-  INLINE uint16_t WRITE16(uint16_t d);
-  INLINE void WRITEBUF(uint8_t *buf, size_t count);
-  INLINE void CS_HIGH(void);
-  INLINE void CS_LOW(void);
+  GFX_INLINE uint16_t WRITE16(uint16_t d);
+  GFX_INLINE void WRITEBUF(uint8_t *buf, size_t count);
+  GFX_INLINE void CS_HIGH(void);
+  GFX_INLINE void CS_LOW(void);
 
 
   int8_t _cs;


### PR DESCRIPTION
Hi,

This PR contains some base changes needed for a potential 2nd PR to add the LT7680 display driver to Arduino_GFX. In summary, these are:
* Add an option to read back from a HWSPI device. I've written it so that by default, it makes no changes to the original library, and is backward compatible with existing projects. However, I've needed to be able to query when the LT7680 is ready to receive the next command. Whilst a fixed delay can be used, I've found this solution to be less than ideal and has caused a problem when the device is not ready or it's just too slow.
* I've added a HWSPI option that does not use a DC pin to control the interpretation of the data being sent. For the LT7680, it always uses 16-bit transfers, but the two most significant bits are used to provide the DC function, and whether it is a read or write function. The least significant byte is used to transfer the actual data. The constructor of the class takes 16-bit values that will be OR'd with the data to set the relevant bits to set the function of subsequent transfers.
* The last change was to make all the drawing functions virtual so that they can all be overridden in derived classes. This was done so that I can use hardware drawing functions of the LT7680 rather than use the Arduino_GFX versions.

For information, the LT7680 datasheet can be found here: https://www.levetop.cn/uploadfiles/2023/05/LT768x_DS_V42_ENG.pdf

I hope you find these edits useful.