### PR TITLE
New Arduino_RGB_Display implementation for board version 3.x

### DIFF
--- a/src/databus/Arduino_ESP32RGBPanel.cpp
+++ b/src/databus/Arduino_ESP32RGBPanel.cpp
@@ -132,7 +132,6 @@ uint16_t *Arduino_ESP32RGBPanel::getFrameBuffer(int16_t w, int16_t h)
   return (uint16_t *)_rgb_panel->fb;
 }
 
-
 #else
 
 // Implementation for ESP32 board version 3.x
@@ -153,7 +152,7 @@ Arduino_ESP32RGBPanel::Arduino_ESP32RGBPanel(
       _b0(b0), _b1(b1), _b2(b2), _b3(b3), _b4(b4),
       _hsync_polarity(hsync_polarity), _hsync_front_porch(hsync_front_porch), _hsync_pulse_width(hsync_pulse_width), _hsync_back_porch(hsync_back_porch),
       _vsync_polarity(vsync_polarity), _vsync_front_porch(vsync_front_porch), _vsync_pulse_width(vsync_pulse_width), _vsync_back_porch(vsync_back_porch),
-      _pclk_active_neg(pclk_active_neg), _prefer_speed(prefer_speed), _useBigEndian(useBigEndian),
+      _pclk_active_neg(pclk_active_neg), _prefer_speed(prefer_speed),
       _de_idle_high(de_idle_high), _pclk_idle_high(pclk_idle_high)
 {
 }
@@ -193,15 +192,13 @@ uint16_t *Arduino_ESP32RGBPanel::getFrameBuffer(int16_t w, int16_t h)
           .vsync_pulse_width = _vsync_pulse_width,
           .vsync_back_porch = _vsync_back_porch,
           .vsync_front_porch = _vsync_front_porch,
-          // struct {
-          //   uint32_t hsync_idle_low: 1;  /*!< The hsync signal is low in IDLE state */
-          //   uint32_t vsync_idle_low: 1;  /*!< The vsync signal is low in IDLE state */
-          //   uint32_t de_idle_high: 1;    /*!< The de signal is high in IDLE state */
-          //   uint32_t pclk_active_neg: 1; /*!< Whether the display data is clocked out on the falling edge of PCLK */
-          //   uint32_t pclk_idle_high: 1;  /*!< The PCLK stays at high level in IDLE phase */
-          // } flags;                         /*!< LCD RGB timing flags */
-
-      },
+          .flags = {
+              .hsync_idle_low = (_hsync_polarity == 0) ? 1 : 0,
+              .vsync_idle_low = (_vsync_polarity == 0) ? 1 : 0,
+              .de_idle_high = _de_idle_high,
+              .pclk_active_neg = _pclk_active_neg,
+              .pclk_idle_high = _pclk_idle_high,
+          }},
       .data_width = 16, // RGB565 in parallel mode, thus 16 bits in width
       .bits_per_pixel = 16,
       .num_fbs = 1,
@@ -212,7 +209,7 @@ uint16_t *Arduino_ESP32RGBPanel::getFrameBuffer(int16_t w, int16_t h)
       .vsync_gpio_num = _vsync,
       .de_gpio_num = _de,
       .pclk_gpio_num = _pclk,
-      .disp_gpio_num = GPIO_NUM_NC,   // -1
+      .disp_gpio_num = GPIO_NUM_NC, // -1
       .data_gpio_nums = {_b0, _b1, _b2, _b3, _b4, _g0, _g1, _g2, _g3, _g4, _g5, _r0, _r1, _r2, _r3, _r4},
 
       .flags = {

--- a/src/databus/Arduino_ESP32RGBPanel.cpp
+++ b/src/databus/Arduino_ESP32RGBPanel.cpp
@@ -1,3 +1,5 @@
+// ESP_LCD_Panel implementation for esp32s3.
+
 #include "Arduino_ESP32RGBPanel.h"
 
 #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
@@ -129,5 +131,103 @@ uint16_t *Arduino_ESP32RGBPanel::getFrameBuffer(int16_t w, int16_t h)
 
   return (uint16_t *)_rgb_panel->fb;
 }
+
+
+#else
+
+// Implementation for ESP32 board version 3.x
+// no need to include a copy of core esp32 types any more.
+
+Arduino_ESP32RGBPanel::Arduino_ESP32RGBPanel(
+    int8_t de, int8_t vsync, int8_t hsync, int8_t pclk,
+    int8_t r0, int8_t r1, int8_t r2, int8_t r3, int8_t r4,
+    int8_t g0, int8_t g1, int8_t g2, int8_t g3, int8_t g4, int8_t g5,
+    int8_t b0, int8_t b1, int8_t b2, int8_t b3, int8_t b4,
+    uint16_t hsync_polarity, uint16_t hsync_front_porch, uint16_t hsync_pulse_width, uint16_t hsync_back_porch,
+    uint16_t vsync_polarity, uint16_t vsync_front_porch, uint16_t vsync_pulse_width, uint16_t vsync_back_porch,
+    uint16_t pclk_active_neg, int32_t prefer_speed, bool useBigEndian,
+    uint16_t de_idle_high, uint16_t pclk_idle_high)
+    : _de(de), _vsync(vsync), _hsync(hsync), _pclk(pclk),
+      _r0(r0), _r1(r1), _r2(r2), _r3(r3), _r4(r4),
+      _g0(g0), _g1(g1), _g2(g2), _g3(g3), _g4(g4), _g5(g5),
+      _b0(b0), _b1(b1), _b2(b2), _b3(b3), _b4(b4),
+      _hsync_polarity(hsync_polarity), _hsync_front_porch(hsync_front_porch), _hsync_pulse_width(hsync_pulse_width), _hsync_back_porch(hsync_back_porch),
+      _vsync_polarity(vsync_polarity), _vsync_front_porch(vsync_front_porch), _vsync_pulse_width(vsync_pulse_width), _vsync_back_porch(vsync_back_porch),
+      _pclk_active_neg(pclk_active_neg), _prefer_speed(prefer_speed), _useBigEndian(useBigEndian),
+      _de_idle_high(de_idle_high), _pclk_idle_high(pclk_idle_high)
+{
+}
+
+bool Arduino_ESP32RGBPanel::begin(int32_t speed)
+{
+  if (speed == GFX_NOT_DEFINED)
+  {
+#ifdef CONFIG_SPIRAM_MODE_QUAD
+    _speed = 6000000L;
+#else
+    _speed = 12000000L;
+#endif
+  }
+  else
+  {
+    _speed = speed;
+  }
+
+  return true;
+}
+
+uint16_t *Arduino_ESP32RGBPanel::getFrameBuffer(int16_t w, int16_t h)
+{
+  uint32_t buffers = 1;
+  void *frame_buffer = nullptr;
+
+  esp_lcd_rgb_panel_config_t panel_config = {
+      .clk_src = LCD_CLK_SRC_DEFAULT, // = LCD_CLK_SRC_PLL160M
+      .timings = {
+          .pclk_hz = (_prefer_speed == GFX_NOT_DEFINED) ? _speed : _prefer_speed,
+          .h_res = w,
+          .v_res = h,
+          .hsync_pulse_width = _hsync_pulse_width,
+          .hsync_back_porch = _hsync_back_porch,
+          .hsync_front_porch = _hsync_front_porch,
+          .vsync_pulse_width = _vsync_pulse_width,
+          .vsync_back_porch = _vsync_back_porch,
+          .vsync_front_porch = _vsync_front_porch,
+          // struct {
+          //   uint32_t hsync_idle_low: 1;  /*!< The hsync signal is low in IDLE state */
+          //   uint32_t vsync_idle_low: 1;  /*!< The vsync signal is low in IDLE state */
+          //   uint32_t de_idle_high: 1;    /*!< The de signal is high in IDLE state */
+          //   uint32_t pclk_active_neg: 1; /*!< Whether the display data is clocked out on the falling edge of PCLK */
+          //   uint32_t pclk_idle_high: 1;  /*!< The PCLK stays at high level in IDLE phase */
+          // } flags;                         /*!< LCD RGB timing flags */
+
+      },
+      .data_width = 16, // RGB565 in parallel mode, thus 16 bits in width
+      .bits_per_pixel = 16,
+      .num_fbs = 1,
+
+      .sram_trans_align = 8,
+      .psram_trans_align = 64,
+      .hsync_gpio_num = _hsync,
+      .vsync_gpio_num = _vsync,
+      .de_gpio_num = _de,
+      .pclk_gpio_num = _pclk,
+      .disp_gpio_num = GPIO_NUM_NC,   // -1
+      .data_gpio_nums = {_b0, _b1, _b2, _b3, _b4, _g0, _g1, _g2, _g3, _g4, _g5, _r0, _r1, _r2, _r3, _r4},
+
+      .flags = {
+          .fb_in_psram = true, // allocate frame buffer from PSRAM
+      }};
+
+  ESP_ERROR_CHECK(esp_lcd_new_rgb_panel(&panel_config, &_panel_handle));
+
+  ESP_ERROR_CHECK(esp_lcd_panel_reset(_panel_handle));
+  ESP_ERROR_CHECK(esp_lcd_panel_init(_panel_handle));
+
+  ESP_ERROR_CHECK(esp_lcd_rgb_panel_get_frame_buffer(_panel_handle, buffers, &frame_buffer));
+
+  return ((uint16_t *)frame_buffer);
+} // getFrameBuffer
+
 #endif // #if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)
 #endif // #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)

--- a/src/databus/Arduino_ESP32RGBPanel.h
+++ b/src/databus/Arduino_ESP32RGBPanel.h
@@ -156,12 +156,10 @@ private:
   uint16_t _vsync_back_porch;
   uint16_t _pclk_active_neg;
   int32_t _prefer_speed;
-  bool _useBigEndian;
   uint16_t _de_idle_high;
   uint16_t _pclk_idle_high;
 
   esp_lcd_panel_handle_t _panel_handle = NULL;
-  esp_lcd_rgb_panel_config_t *_rgb_panel;
 };
 
 #endif // #if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)

--- a/src/databus/Arduino_ESP32RGBPanel.h
+++ b/src/databus/Arduino_ESP32RGBPanel.h
@@ -1,5 +1,20 @@
 #pragma once
 
+// ESP_LCD_Panel implementation for esp32s3.
+
+// This panel implementation requires a hardware setup with 
+//  * RGB LCD peripheral supported (esps3 for now)
+//  * Octal PSRAM onboard
+//  * RGB panel, 16 bit-width, with HSYNC, VSYNC and DE signal
+//
+// It uses a Single Frame Buffer in PSRAM
+//
+// See: (ESP32 board version 3.x)
+// * https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/lcd/rgb_lcd.html
+// * https://github.com/espressif/esp-idf/blob/master/examples/peripherals/lcd/rgb_panel/README.md
+// 
+// The prior implementation (ESP32 board version 2.x) was largely undocumented.
+
 #include "Arduino_DataBus.h"
 
 #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
@@ -93,6 +108,60 @@ private:
 
   esp_lcd_panel_handle_t _panel_handle = NULL;
   esp_rgb_panel_t *_rgb_panel;
+};
+
+#else
+
+// Implementation for ESP32 board version 3.x
+// no need to include a copy of core esp32 types any more.
+
+#include "esp_lcd_panel_rgb.h"
+#include "esp_lcd_panel_ops.h"
+
+#include "esp32s3/rom/cache.h"
+// This function is located in ROM (also see esp_rom/${target}/ld/${target}.rom.ld)
+extern int Cache_WriteBack_Addr(uint32_t addr, uint32_t size);
+
+class Arduino_ESP32RGBPanel
+{
+public:
+  Arduino_ESP32RGBPanel(
+      int8_t de, int8_t vsync, int8_t hsync, int8_t pclk,
+      int8_t r0, int8_t r1, int8_t r2, int8_t r3, int8_t r4,
+      int8_t g0, int8_t g1, int8_t g2, int8_t g3, int8_t g4, int8_t g5,
+      int8_t b0, int8_t b1, int8_t b2, int8_t b3, int8_t b4,
+      uint16_t hsync_polarity, uint16_t hsync_front_porch, uint16_t hsync_pulse_width, uint16_t hsync_back_porch,
+      uint16_t vsync_polarity, uint16_t vsync_front_porch, uint16_t vsync_pulse_width, uint16_t vsync_back_porch,
+      uint16_t pclk_active_neg = 0, int32_t prefer_speed = GFX_NOT_DEFINED, bool useBigEndian = false,
+      uint16_t de_idle_high = 0, uint16_t pclk_idle_high = 0);
+
+  bool begin(int32_t speed = GFX_NOT_DEFINED);
+
+  uint16_t *getFrameBuffer(int16_t w, int16_t h);
+
+protected:
+private:
+  int32_t _speed;
+  int8_t _de, _vsync, _hsync, _pclk;
+  int8_t _r0, _r1, _r2, _r3, _r4;
+  int8_t _g0, _g1, _g2, _g3, _g4, _g5;
+  int8_t _b0, _b1, _b2, _b3, _b4;
+  uint16_t _hsync_polarity;
+  uint16_t _hsync_front_porch;
+  uint16_t _hsync_pulse_width;
+  uint16_t _hsync_back_porch;
+  uint16_t _vsync_polarity;
+  uint16_t _vsync_front_porch;
+  uint16_t _vsync_pulse_width;
+  uint16_t _vsync_back_porch;
+  uint16_t _pclk_active_neg;
+  int32_t _prefer_speed;
+  bool _useBigEndian;
+  uint16_t _de_idle_high;
+  uint16_t _pclk_idle_high;
+
+  esp_lcd_panel_handle_t _panel_handle = NULL;
+  esp_lcd_rgb_panel_config_t *_rgb_panel;
 };
 
 #endif // #if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)

--- a/src/display/Arduino_RGB_Display.cpp
+++ b/src/display/Arduino_RGB_Display.cpp
@@ -1,7 +1,6 @@
 #include "../Arduino_DataBus.h"
 
 #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
-#if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)
 
 #include "../Arduino_GFX.h"
 #include "Arduino_RGB_Display.h"
@@ -519,5 +518,4 @@ uint16_t *Arduino_RGB_Display::getFramebuffer()
   return _framebuffer;
 }
 
-#endif // #if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)
 #endif // #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)

--- a/src/display/Arduino_RGB_Display.h
+++ b/src/display/Arduino_RGB_Display.h
@@ -3,7 +3,6 @@
 #include "../Arduino_DataBus.h"
 
 #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
-#if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)
 
 #include "../Arduino_GFX.h"
 #include "../databus/Arduino_ESP32RGBPanel.h"
@@ -2298,5 +2297,4 @@ protected:
 private:
 };
 
-#endif // #if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)
 #endif // #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)


### PR DESCRIPTION
As the idf-sdk has got major changes for the panel support since 3.x there is now a new implementation using the published APIs.

See

* https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/lcd/rgb_lcd.html
* https://github.com/espressif/esp-idf/blob/master/examples/peripherals/lcd/rgb_panel/README.md

Checked with ESP32_8048S043
Benchmark results are almost the same.

<img src="https://github.com/user-attachments/assets/e01a16c1-4a51-412c-bcd4-c8bd0ba22edd" width="600" 
alt ="Arduino_RGB_Display on ESP32_8048S043"/>
