### PR TITLE
define pgm_read_glyph_ptr() and pgm_read_pointer() as static

### DIFF
--- a/src/Arduino_GFX.h
+++ b/src/Arduino_GFX.h
@@ -138,7 +138,7 @@
 #endif
 
 #if !defined(ATTINY_CORE)
-GFX_INLINE GFXglyph *pgm_read_glyph_ptr(const GFXfont *gfxFont, uint8_t c)
+GFX_INLINE static GFXglyph *pgm_read_glyph_ptr(const GFXfont *gfxFont, uint8_t c)
 {
 #ifdef __AVR__
   return &(((GFXglyph *)pgm_read_pointer(&gfxFont->glyph))[c]);
@@ -150,7 +150,7 @@ GFX_INLINE GFXglyph *pgm_read_glyph_ptr(const GFXfont *gfxFont, uint8_t c)
 #endif //__AVR__
 }
 
-GFX_INLINE uint8_t *pgm_read_bitmap_ptr(const GFXfont *gfxFont)
+GFX_INLINE static uint8_t *pgm_read_bitmap_ptr(const GFXfont *gfxFont)
 {
 #ifdef __AVR__
   return (uint8_t *)pgm_read_pointer(&gfxFont->bitmap);


### PR DESCRIPTION
functions defined in header file (.h) must be defined as static, otherwise there could a be situations when linker fails with 'multiple definition' error'

i.e.
```
(.text+0x0): multiple definition of `_Z18pgm_read_glyph_ptrPK7GFXfonth'; .pio/build/hdwf2_my/src/actions.cpp.o (symbol from plugin):(.text+0x0): first defined here
(.text+0x0): multiple definition of `_Z19pgm_read_bitmap_ptrPK7GFXfont'; .pio/build/hdwf2_my/src/actions.cpp.o (symbol from plugin):(.text+0x0): first defined here
```