### PR TITLE
Force `SPI_MODE0` for some displays

### DIFF
--- a/src/display/Arduino_ST7796.cpp
+++ b/src/display/Arduino_ST7796.cpp
@@ -3,6 +3,7 @@
  * https://github.com/adafruit/Adafruit-GFX-Library.git
  */
 #include "Arduino_ST7796.h"
+#include "SPI.h"
 
 Arduino_ST7796::Arduino_ST7796(
     Arduino_DataBus *bus, int8_t rst, uint8_t r,
@@ -14,6 +15,14 @@ Arduino_ST7796::Arduino_ST7796(
 
 bool Arduino_ST7796::begin(int32_t speed)
 {
+#if defined(ESP32) || defined(ARDUINO_ARCH_NRF52840)
+  _override_datamode = SPI_MODE3;
+#elif defined(ESP8266)
+  _override_datamode = SPI_MODE2;
+#elif defined(__AVR__)
+  _override_datamode = SPI_MODE0;
+#endif
+
   return Arduino_TFT::begin(speed);
 }
 


### PR DESCRIPTION
Datasheets for these displays indicate data should be sampled on rising edge of clock, which corresponds to `SPI_MODE0`.

* ILI9486
* ILI9488
* ST7796

The ST7796 and ILI9488 did not work on the AVR platform, and this change fixes them (#635). I changed ILI9486 as well since it seems very similar.

From a look through their datasheets, it looks like a few other displays should also use `SPI_MODE0`, but I didn't want to change them in case they work on other platforms as-is.