### PR TITLE
Update: ESP32+RGB

### DIFF
--- a/src/databus/Arduino_ESP32RGBPanel.cpp
+++ b/src/databus/Arduino_ESP32RGBPanel.cpp
@@ -2,7 +2,8 @@
 
 #include "Arduino_ESP32RGBPanel.h"
 
-#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
+//#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
+#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4)  //Modify
 Arduino_ESP32RGBPanel::Arduino_ESP32RGBPanel(
     int8_t de, int8_t vsync, int8_t hsync, int8_t pclk,
     int8_t r0, int8_t r1, int8_t r2, int8_t r3, int8_t r4,

--- a/src/display/Arduino_RGB_Display.cpp
+++ b/src/display/Arduino_RGB_Display.cpp
@@ -1,6 +1,7 @@
 #include "../Arduino_DataBus.h"
 
-#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
+//#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
+#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4)  //Modify
 
 #include "../Arduino_GFX.h"
 #include "Arduino_RGB_Display.h"

--- a/src/display/Arduino_RGB_Display.h
+++ b/src/display/Arduino_RGB_Display.h
@@ -2,7 +2,8 @@
 
 #include "../Arduino_DataBus.h"
 
-#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
+//#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)
+#if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4)  //Modify
 
 #include "../Arduino_GFX.h"
 #include "../databus/Arduino_ESP32RGBPanel.h"


### PR DESCRIPTION
ESP32P4 uses the RGB interface. Tested and passed with ESP32 Core 3.20 and GFX Library 1.60.