### PR TITLE
Bugfix: Update Arduino_ESP32RGBPanel.h

### DIFF
--- a/src/databus/Arduino_ESP32RGBPanel.h
+++ b/src/databus/Arduino_ESP32RGBPanel.h
@@ -55,8 +55,8 @@
 #endif
 
 
-//#if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)
-#if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR >5)
+#if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR < 3)
+//#if (!defined(ESP_ARDUINO_VERSION_MAJOR)) || (ESP_ARDUINO_VERSION_MAJOR >5)
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_interface.h"


### PR DESCRIPTION
The lines 58 and 59 of src/databus/Arduino_ESP32RGBPanel.h prevented the library to work with an ESP32S3 (and possibly with ESP32-P4) since the same check in Arduino_ESP32RGBPanel.cpp line 146 causes it to use  "esp_rgb_panel_t" which is not defined without this fix.

Would you be so kind to review these few lines to make your awesome library work with my ESP32-S3 board (Waveshare ESP32-S3 Pico) out of the box again? It works flawlessly with my other boards. Thank you for your great work!

Greetings,

Fred Fonkle