### PR TITLE
Fix a comment that is meant to say height instead of width in C05300 display.

### DIFF
--- a/src/display/Arduino_CO5300.h
+++ b/src/display/Arduino_CO5300.h
@@ -5,7 +5,7 @@
 #include "../Arduino_OLED.h"
 
 #define CO5300_TFTWIDTH 480  ///< CO5300 max TFT width
-#define CO5300_TFTHEIGHT 480 ///< CO5300 max TFT width
+#define CO5300_TFTHEIGHT 480 ///< CO5300 max TFT height
 
 #define CO5300_RST_DELAY 200    ///< delay ms wait for reset finish
 #define CO5300_SLPIN_DELAY 120  ///< delay ms wait for sleep in finish


### PR DESCRIPTION
Hello. 
I was using this library to make the initial checks for my CO5300 based screen and found a small typo that needed to be fixed.
Thank you.

Ginés.