### PR TITLE
Crash fix with drawChar()

### DIFF
--- a/src/display/Arduino_RGB_Display.cpp
+++ b/src/display/Arduino_RGB_Display.cpp
@@ -79,7 +79,7 @@ bool Arduino_RGB_Display::begin(int32_t speed)
 
 void Arduino_RGB_Display::writePixelPreclipped(int16_t x, int16_t y, uint16_t color)
 {
-  int32_t y2;
+  int32_t y2 = y;
   switch (_rotation)
   {
   case 1:


### PR DESCRIPTION
Uninitialized local variable results in “Core x panic'ed (StoreProhibited)” exception when drawing size 1 text with rotation 0.