### PR TITLE
Fix build error with ESP32 Arduino core 3.3.6

### DIFF
--- a/src/databus/Arduino_ESP32SPI.cpp
+++ b/src/databus/Arduino_ESP32SPI.cpp
@@ -121,7 +121,14 @@ static void _on_apb_change(void *arg, apb_change_ev_t ev_type, uint32_t old_apb,
   }
   else
   {
+    // Fix for ESP32 Arduino core 3.3.6+ compatibility
+    // Ref: https://github.com/espressif/arduino-esp32/pull/12265
+    // Changed: spiFrequencyToClockDiv(freq) -> spiFrequencyToClockDiv(spi, freq)
+#if defined(ESP_ARDUINO_VERSION) && (ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 3, 6))
+    _spi->dev->clock.val = spiFrequencyToClockDiv(_spi, old_apb / ((_spi->dev->clock.clkdiv_pre + 1) * (_spi->dev->clock.clkcnt_n + 1)));
+#else
     _spi->dev->clock.val = spiFrequencyToClockDiv(old_apb / ((_spi->dev->clock.clkdiv_pre + 1) * (_spi->dev->clock.clkcnt_n + 1)));
+#endif
     SPI_MUTEX_UNLOCK();
   }
 }
@@ -168,7 +175,14 @@ bool Arduino_ESP32SPI::begin(int32_t speed, int8_t dataMode)
 
   if (!_div)
   {
+    // Fix for ESP32 Arduino core 3.3.6+ compatibility
+    // Ref: https://github.com/espressif/arduino-esp32/pull/12265
+    // Changed: spiFrequencyToClockDiv(freq) -> spiFrequencyToClockDiv(spi, freq)
+#if defined(ESP_ARDUINO_VERSION) && (ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 3, 6))
+    _div = spiFrequencyToClockDiv(&_spi_bus_array[_spi_num], _speed);
+#else
     _div = spiFrequencyToClockDiv(_speed);
+#endif
   }
 
   // set pin mode

--- a/src/databus/Arduino_ESP32SPIDMA.cpp
+++ b/src/databus/Arduino_ESP32SPIDMA.cpp
@@ -58,10 +58,16 @@ bool Arduino_ESP32SPIDMA::begin(int32_t speed, int8_t dataMode)
   _speed = (speed == GFX_NOT_DEFINED) ? SPI_DEFAULT_FREQ : speed;
   _dataMode = (dataMode == GFX_NOT_DEFINED) ? SPI_MODE0 : dataMode;
 
+  // Fix for ESP32 Arduino core 3.3.6+ compatibility
+  // Ref: https://github.com/espressif/arduino-esp32/pull/12265
+  // Note: _div is not used in DMA mode (speed is passed directly to ESP-IDF driver),
+  // so we skip the call entirely for 3.3.6+ to avoid the changed function signature.
+#if !defined(ESP_ARDUINO_VERSION) || (ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 3, 6))
   if (!_div)
   {
     _div = spiFrequencyToClockDiv(_speed);
   }
+#endif
 
   // set pin mode
   if (_dc != GFX_NOT_DEFINED)


### PR DESCRIPTION
## Summary

Fixes #759

ESP32 Arduino core 3.3.6 changed the `spiFrequencyToClockDiv()` function signature to add an `spi_t` pointer parameter for ESP32-P4 clock source management (ref: https://github.com/espressif/arduino-esp32/pull/12265).

This PR updates `Arduino_ESP32SPI.cpp` and `Arduino_ESP32SPIDMA.cpp` to handle both old and new API using version detection.

## Changes

- `Arduino_ESP32SPI.cpp`: Added conditional compilation for both API versions
- `Arduino_ESP32SPIDMA.cpp`: Skip unused `_div` calculation on 3.3.6+ (not used in DMA mode)

## Testing

- ESP32 Arduino core 3.3.5: ✅ Build passed
- ESP32 Arduino core 3.3.6: ✅ Build passed