### PR TITLE
Fix a bug where printing a character above the screen throws segmentation fault

### DIFF
--- a/src/Arduino_GFX.cpp
+++ b/src/Arduino_GFX.cpp
@@ -2105,7 +2105,7 @@ void Arduino_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
             {
               if (bits & 0x80)
               {
-                writePixelPreclipped(curX, curY, color);
+                writePixel(curX, curY, color);
               }
             }
           }


### PR DESCRIPTION
I have a small project that takes a long text and scrolls it across the screen by offsetting the cursor to negative Y value. Unfortunately in some circumstances this calls writePixelPreclipped with a negative Y, calculates negative POS, and subsequently throws a segmentation fault. 

After changing this line in my local copy, it no longer breaks. This is probably not the correct way to solve it.