### PR TITLE
Lilygo T-Display S3 AMOLED Plus

### DIFF
--- a/examples/PDQgraphicstest/Arduino_GFX_dev_device.h
+++ b/examples/PDQgraphicstest/Arduino_GFX_dev_device.h
@@ -37,6 +37,7 @@
 // #define LILYGO_T_DISPLAY_S3
 // #define LILYGO_T_Display_S3_AMOLED
 // #define LILYGO_T_Display_S3_AMOLED_1_64
+// #define LILYGO_T_Display_S3_AMOLED_PLUS
 // #define LILYGO_T_Display_S3_LONG
 // #define LILYGO_T_DISPLAY_S3_PRO
 // #define LILYGO_T_QT_PRO
@@ -655,6 +656,19 @@ Arduino_GFX *g = new Arduino_CO5300(
 #define CANVAS
 Arduino_Canvas *gfx = new Arduino_Canvas(
     280 /* width */, 456 /* height */, g, 0 /* output_x */, 0 /* output_y */, 0 /* rotation */);
+
+#elif defined(LILYGO_T_Display_S3_AMOLED_PLUS)
+#define GFX_DEV_DEVICE LILYGO_T_DISPLAY_S3_AMOLED_PLUS
+// GPIO 38 = PMICEnPins: must be HIGH to power the display
+#define DEV_DEVICE_INIT()                    \
+    {                                        \
+        pinMode(38 /* PMIC_EN */, OUTPUT);   \
+        digitalWrite(38 /* PMIC_EN */, HIGH); \
+        delay(100);                          \
+    }
+// T-Display S3 AMOLED Plus: RM67162 over SPI (DC=7, CS=6, SCK=47, MOSI=18, RST=17)
+Arduino_DataBus *bus = new Arduino_ESP32SPI(7 /* DC */, 6 /* CS */, 47 /* SCK */, 18 /* MOSI */, GFX_NOT_DEFINED /* MISO */);
+Arduino_GFX *gfx = new Arduino_RM67162(bus, 17 /* RST */, 0 /* rotation */, false /* IPS */, rm67162_spi_init_operations, sizeof(rm67162_spi_init_operations));
 
 #elif defined(LILYGO_T_Display_S3_LONG)
 #define GFX_DEV_DEVICE LILYGO_T_DISPLAY_S3_LONG

--- a/src/display/Arduino_RM67162.cpp
+++ b/src/display/Arduino_RM67162.cpp
@@ -1,8 +1,8 @@
 #include "Arduino_RM67162.h"
 #include "SPI.h"
 
-Arduino_RM67162::Arduino_RM67162(Arduino_DataBus *bus, int8_t rst, uint8_t r, bool ips)
-    : Arduino_TFT(bus, rst, r, ips, RM67162_TFTWIDTH, RM67162_TFTHEIGHT, 0, 0, 0, 0)
+Arduino_RM67162::Arduino_RM67162(Arduino_DataBus *bus, int8_t rst, uint8_t r, bool ips, const uint8_t *init_operations, int16_t init_operations_len)
+    : Arduino_TFT(bus, rst, r, ips, RM67162_TFTWIDTH, RM67162_TFTHEIGHT, 0, 0, 0, 0), _init_operations(init_operations), _init_operations_len(init_operations_len)
 {
 }
 
@@ -78,6 +78,13 @@ void Arduino_RM67162::displayOff(void)
   delay(RM67162_SLPIN_DELAY);
 }
 
+void Arduino_RM67162::setBrightness(uint8_t brightness)
+{
+  _bus->beginWrite();
+  _bus->writeC8D8(RM67162_BRIGHTNESS, brightness);
+  _bus->endWrite();
+}
+
 // Companion code to the above tables.  Reads and issues
 // a series of LCD commands stored in PROGMEM byte array.
 void Arduino_RM67162::tftInit()
@@ -99,7 +106,7 @@ void Arduino_RM67162::tftInit()
     delay(RM67162_RST_DELAY);
   }
 
-  _bus->batchOperation(rm67162_init_operations, sizeof(rm67162_init_operations));
+  _bus->batchOperation(_init_operations, _init_operations_len);
 
   invertDisplay(false);
 }

--- a/src/display/Arduino_RM67162.h
+++ b/src/display/Arduino_RM67162.h
@@ -52,10 +52,41 @@ static const uint8_t rm67162_init_operations[] = {
     WRITE_C8_D8, RM67162_BRIGHTNESS, 0xBF, // Write Display Brightness   MAX_VAL=0XFF
     END_WRITE};
 
+// SPI-specific init sequence for T-Display S3 AMOLED Plus (RM67162 in SPI mode)
+// Uses 0x75 pixel format (16-bit for SPI) and page register setup
+static const uint8_t rm67162_spi_init_operations[] = {
+    BEGIN_WRITE,
+    WRITE_C8_D8, 0xFE, 0x04,              // SET PAGE3
+    WRITE_C8_D8, 0x6A, 0x00,
+    WRITE_C8_D8, 0xFE, 0x05,              // SET PAGE4
+    WRITE_C8_D8, 0xFE, 0x07,              // SET PAGE6
+    WRITE_C8_D8, 0x07, 0x4F,
+    WRITE_C8_D8, 0xFE, 0x01,              // SET PAGE0
+    WRITE_C8_D8, 0x2A, 0x02,
+    WRITE_C8_D8, 0x2B, 0x73,
+    WRITE_C8_D8, 0xFE, 0x0A,              // SET PAGE9
+    WRITE_C8_D8, 0x29, 0x10,
+    WRITE_C8_D8, 0xFE, 0x00,              // Return to page 0
+    WRITE_C8_D8, RM67162_BRIGHTNESS, 0xBF,
+    WRITE_C8_D8, 0x53, 0x20,
+    WRITE_C8_D8, 0x35, 0x00,
+    WRITE_C8_D8, RM67162_PIXFMT, 0x75,   // Interface Pixel Format 16bit/pixel (SPI)
+    WRITE_C8_D8, 0xC4, 0x80,
+    WRITE_COMMAND_8, RM67162_SLPOUT,      // Sleep Out
+    END_WRITE,
+
+    DELAY, RM67162_SLPOUT_DELAY,
+
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, RM67162_DISPON,      // Display on
+    END_WRITE,
+
+    DELAY, 20};
+
 class Arduino_RM67162 : public Arduino_TFT
 {
 public:
-  Arduino_RM67162(Arduino_DataBus *bus, int8_t rst = GFX_NOT_DEFINED, uint8_t r = 0, bool ips = false);
+  Arduino_RM67162(Arduino_DataBus *bus, int8_t rst = GFX_NOT_DEFINED, uint8_t r = 0, bool ips = false, const uint8_t *init_operations = rm67162_init_operations, int16_t init_operations_len = sizeof(rm67162_init_operations));
 
   bool begin(int32_t speed = GFX_NOT_DEFINED) override;
 
@@ -66,9 +97,12 @@ public:
   void invertDisplay(bool) override;
   void displayOn() override;
   void displayOff() override;
+  void setBrightness(uint8_t brightness) override;
 
 protected:
   void tftInit() override;
 
 private:
+  const uint8_t *_init_operations;
+  int16_t _init_operations_len;
 };

--- a/src/display/Arduino_RM67162.h
+++ b/src/display/Arduino_RM67162.h
@@ -97,7 +97,7 @@ public:
   void invertDisplay(bool) override;
   void displayOn() override;
   void displayOff() override;
-  void setBrightness(uint8_t brightness) override;
+  void setBrightness(uint8_t brightness);
 
 protected:
   void tftInit() override;


### PR DESCRIPTION
Adds support to Lilygo T-Disply S3 AMOLED Plus, which is based on RM67162 driver usind SPI bus instead of QSPI.

Adds Brightness method for the RM67162.

https://lilygo.cc/products/t-display-s3-amoled-plus