### PR TITLE
Added SPI mode to ST7796 (Fix for waveshare esp32 3.5 display)

### DIFF
--- a/src/display/Arduino_ST7796.cpp
+++ b/src/display/Arduino_ST7796.cpp
@@ -15,13 +15,25 @@ Arduino_ST7796::Arduino_ST7796(
 
 bool Arduino_ST7796::begin(int32_t speed)
 {
+  return begin(speed, GFX_NOT_DEFINED);
+}
+
+bool Arduino_ST7796::begin(int32_t speed, int32_t mode)
+{
+  if (mode != GFX_NOT_DEFINED)
+  {
+    _override_datamode = mode;
+  }
+  else
+  {
 #if defined(ESP32) || defined(ARDUINO_ARCH_NRF52840)
-  _override_datamode = SPI_MODE3;
+    _override_datamode = SPI_MODE3;
 #elif defined(ESP8266)
-  _override_datamode = SPI_MODE2;
+    _override_datamode = SPI_MODE2;
 #elif defined(__AVR__)
-  _override_datamode = SPI_MODE0;
+    _override_datamode = SPI_MODE0;
 #endif
+  }
 
   return Arduino_TFT::begin(speed);
 }

--- a/src/display/Arduino_ST7796.h
+++ b/src/display/Arduino_ST7796.h
@@ -108,6 +108,7 @@ public:
       uint8_t col_offset1 = 0, uint8_t row_offset1 = 0, uint8_t col_offset2 = 0, uint8_t row_offset2 = 0);
 
   bool begin(int32_t speed = GFX_NOT_DEFINED) override;
+  bool begin(int32_t speed, int32_t mode);
 
   void setRotation(uint8_t r) override;
 


### PR DESCRIPTION
Must pass in SPI_MODE0 for the tft for this device

Apologies for failed compilation on the previous pr's. This one was tested and compiles.

This is a fix for this bug https://github.com/moononournation/Arduino_GFX/issues/788 
