### PR TITLE
Fix SSD1351 display on/off

### DIFF
--- a/src/display/Arduino_SSD1351.cpp
+++ b/src/display/Arduino_SSD1351.cpp
@@ -131,10 +131,10 @@ void Arduino_SSD1351::invertDisplay(bool i)
 
 void Arduino_SSD1351::displayOn(void)
 {
-  _bus->sendCommand(SSD1351_DISPLAYALLON);
+  _bus->sendCommand(SSD1351_DISPLAYON);
 }
 
 void Arduino_SSD1351::displayOff(void)
 {
-  _bus->sendCommand(SSD1351_DISPLAYALLOFF);
+  _bus->sendCommand(SSD1351_DISPLAYOFF);
 }


### PR DESCRIPTION
SSD1351_DISPLAYALLON and SSD1351_DISPLAYALLOFF commands do not work on SSD1351 display. Here is the [code](https://github.com/adafruit/Adafruit-SSD1351-library/blob/8c1ca3b367460498c9258c683e8dbd11770d8b83/Adafruit_SSD1351.cpp#L377) from Adafruit library.