### PR TITLE
Fix out-of-bounds write in drawChar() classic glcdfont path

### DIFF
--- a/src/Arduino_GFX.cpp
+++ b/src/Arduino_GFX.cpp
@@ -2219,12 +2219,12 @@ void Arduino_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
       for (int8_t i = 0; i < 5; ++i, ++curX) // Char bitmap = 5 columns
       {
         uint8_t line = pgm_read_byte(&font[c * 5 + i]);
-        if (curX <= _max_text_x)
+        if ((curX >= _min_text_x) && (curX <= _max_text_x))
         {
           curY = y;
           for (int8_t j = 0; j < 8; ++j, ++curY, line >>= 1)
           {
-            if (curY <= _max_text_y)
+            if ((curY >= _min_text_y) && (curY <= _max_text_y))
             {
               if (line & 1)
               {


### PR DESCRIPTION
## Problem

The classic built-in glcdfont branch in `Arduino_GFX::drawChar()` sends pixels directly to `writePixelPreclipped()`. Its loops checked `_max_text_x` and `_max_text_y`, but not the corresponding minimum text bounds.

When a partially visible character starts above or left of the text area, negative coordinates can therefore reach canvas implementations that index their framebuffer directly and rely on the caller to have clipped them.

## Fix

Add the missing `_min_text_x` and `_min_text_y` checks to the existing column and row conditions. Visible pixels continue to use `writePixelPreclipped()` directly; only pixels outside the top or left text boundary are skipped.

## Verification

I built a host harness against the real repository `Arduino_G.cpp`, `Arduino_GFX.cpp`, and `Arduino_Canvas.cpp`, using a `ProbeCanvas` subclass only to record coordinates before forwarding each call to the real canvas implementation.

- Before the fix, `setCursor(-3, -2); print("A")` made 40 preclipped writes: 13 had framebuffer offsets outside `[0, 4096)`, and 15 more had invalid coordinates that mapped to unrelated in-buffer pixels.
- With the minimum-bound checks, the same case makes 12 visible preclipped writes and zero invalid-coordinate or out-of-buffer writes.
- `setCursor(-3, 5)` likewise completes with 16 visible writes and zero invalid writes.
- Fully visible and default canvas-clipped framebuffer hashes match the prior bounds-safe implementation.
- A custom text bound starting at `(4, 5)` also clips pixels against its minimum x/y values.

The host harness compiles and runs successfully. Physical display hardware was not used.
