### PR TITLE
Fix GCD01 90° and 270° rotations

### DIFF
--- a/src/display/Arduino_GC9D01.cpp
+++ b/src/display/Arduino_GC9D01.cpp
@@ -44,13 +44,13 @@ void Arduino_GC9D01::setRotation(uint8_t r)
   switch (_rotation % 4)
   {
     case 1: // Landscape (Portrait + 90°)
-    r = GC9D01_MADCTL_MX | GC9D01_MADCTL_MV | GC9D01_MADCTL_BGR;
+    r = GC9D01_MADCTL_MX | GC9D01_MADCTL_MY | GC9D01_MADCTL_MV | GC9D01_MADCTL_ML | GC9D01_MADCTL_BGR;
     break;
   case 2: // Inverter Portrait
     r = GC9D01_MADCTL_MX | GC9D01_MADCTL_MY | GC9D01_MADCTL_BGR;
     break;
   case 3: // Inverted Landscape
-    r = GC9D01_MADCTL_MV | GC9D01_MADCTL_MY | GC9D01_MADCTL_BGR;
+    r = GC9D01_MADCTL_MV | GC9D01_MADCTL_ML | GC9D01_MADCTL_BGR;
     break;
   default: // case 0: (Portrait)
     r = GC9D01_MADCTL_BGR;


### PR DESCRIPTION
The GC9D01 runs in dual-gate mode (init sends 0xBF=0x01) because even and odd gate lines are driven from opposite sides of the panel. I saw even and odd line-swap on 90° and 270° rotations so I fixed it with the ML bit (0x10 = line-address order).
Before:
<img width="1635" height="1225" alt="image" src="https://github.com/user-attachments/assets/50c07be2-44c4-4f1c-9c58-2caf68eaca54" />

After:
<img width="1548" height="1196" alt="image" src="https://github.com/user-attachments/assets/ec114617-36a5-4792-bb31-bc12d7a32689" />
