### PR TITLE
Batch RGB framebuffer cache sync per transaction

### DIFF
--- a/examples/PDQgraphicstest/Arduino_GFX_dev_device.h
+++ b/examples/PDQgraphicstest/Arduino_GFX_dev_device.h
@@ -31,6 +31,7 @@
 // #define JC3636W518
 // #define JC4880P433
 // #define JC8012P4A1
+// #define JC8048W550
 // #define LILYGO_T_DECK
 // #define LILYGO_T_DECK_PLUS
 // #define LILYGO_T_DISPLAY
@@ -274,6 +275,23 @@ Arduino_ESP32RGBPanel *rgbpanel = new Arduino_ESP32RGBPanel(
     0 /* de_idle_high */, 0 /* pclk_idle_high */, 0 /* bounce_buffer_size_px */);
 Arduino_RGB_Display *gfx = new Arduino_RGB_Display(
     800 /* width */, 480 /* height */, rgbpanel, 0 /* rotation */, true /* auto_flush */);
+
+#elif defined(JC8048W550)
+#define GFX_DEV_DEVICE JC8048W550
+#define GFX_BL 2
+#define RGB_PANEL
+Arduino_ESP32RGBPanel *rgbpanel = new Arduino_ESP32RGBPanel(
+    40 /* DE */, 41 /* VSYNC */, 39 /* HSYNC */, 42 /* PCLK */,
+    45 /* R0 */, 48 /* R1 */, 47 /* R2 */, 21 /* R3 */, 14 /* R4 */,
+    5 /* G0 */, 6 /* G1 */, 7 /* G2 */, 15 /* G3 */, 16 /* G4 */, 4 /* G5 */,
+    8 /* B0 */, 3 /* B1 */, 46 /* B2 */, 9 /* B3 */, 1 /* B4 */,
+    0 /* hsync_polarity */, 8 /* hsync_front_porch */, 4 /* hsync_pulse_width */, 8 /* hsync_back_porch */,
+    0 /* vsync_polarity */, 8 /* vsync_front_porch */, 4 /* vsync_pulse_width */, 8 /* vsync_back_porch */,
+    1 /* pclk_active_neg */, 16000000 /* prefer_speed */);
+
+Arduino_RGB_Display *gfx = new Arduino_RGB_Display(
+    800 /* width */, 480 /* height */, rgbpanel, 0 /* rotation */, true /* auto_flush */);
+
 
 #elif defined(ESP32_C3_OLED_12864)
 #define GFX_DEV_DEVICE ESP32_C3_OLED_12864

--- a/src/display/Arduino_RGB_Display.cpp
+++ b/src/display/Arduino_RGB_Display.cpp
@@ -104,7 +104,7 @@ void Arduino_RGB_Display::writePixelPreclipped(int16_t x, int16_t y, uint16_t co
   *fb = color;
   if (_auto_flush)
   {
-    Cache_WriteBack_Addr((uint32_t)fb, 2);
+    _dirty(fb, 2);
   }
 }
 
@@ -163,7 +163,7 @@ void Arduino_RGB_Display::writeFastVLineCore(int16_t x, int16_t y,
           while (h--)
           {
             *fb = color;
-            Cache_WriteBack_Addr((uint32_t)fb, 2);
+            _dirty(fb, 2);
             fb += _fb_width;
           }
         }
@@ -230,7 +230,7 @@ void Arduino_RGB_Display::writeFastHLineCore(int16_t x, int16_t y,
         x += COL_OFFSET1;
         y += ROW_OFFSET1;
         uint16_t *fb = _framebuffer + ((int32_t)y * _fb_width) + x;
-        uint32_t cachePos = (uint32_t)fb;
+        uint16_t *cachePos = fb;
         int16_t writeSize = w * 2;
         while (w--)
         {
@@ -238,7 +238,7 @@ void Arduino_RGB_Display::writeFastHLineCore(int16_t x, int16_t y,
         }
         if (_auto_flush)
         {
-          Cache_WriteBack_Addr(cachePos, writeSize);
+          _dirty(cachePos, writeSize);
         }
       }
     }
@@ -279,7 +279,7 @@ void Arduino_RGB_Display::writeFillRectPreclipped(int16_t x, int16_t y,
   y += ROW_OFFSET1;
   uint16_t *row = _framebuffer;
   row += y * _fb_width;
-  uint32_t cachePos = (uint32_t)row;
+  uint16_t *cachePos = row;
   row += x;
   for (int j = 0; j < h; j++)
   {
@@ -291,7 +291,7 @@ void Arduino_RGB_Display::writeFillRectPreclipped(int16_t x, int16_t y,
   }
   if (_auto_flush)
   {
-    Cache_WriteBack_Addr(cachePos, _fb_width * h * 2);
+    _dirty(cachePos, _fb_width * h * 2);
   }
 }
 
@@ -341,7 +341,7 @@ void Arduino_RGB_Display::drawIndexedBitmap(int16_t x, int16_t y, uint8_t *bitma
       y += ROW_OFFSET1;
       uint16_t *row = _framebuffer;
       row += y * _fb_width;
-      uint32_t cachePos = (uint32_t)row;
+      uint16_t *cachePos = row;
       row += x;
       for (int j = 0; j < h; j++)
       {
@@ -354,7 +354,7 @@ void Arduino_RGB_Display::drawIndexedBitmap(int16_t x, int16_t y, uint8_t *bitma
       }
       if (_auto_flush)
       {
-        Cache_WriteBack_Addr(cachePos, _fb_width * h * 2);
+        _dirty(cachePos, _fb_width * h * 2);
       }
     }
   }
@@ -402,27 +402,27 @@ void Arduino_RGB_Display::draw16bitRGBBitmap(int16_t x, int16_t y,
   {
     if (_auto_flush)
     {
-      uint32_t cachePos;
+      uint16_t *cachePos;
       size_t cache_size;
       switch (_rotation)
       {
       case 1:
-        cachePos = (uint32_t)(_framebuffer + (x * _fb_width));
+        cachePos = _framebuffer + (x * _fb_width);
         cache_size = _fb_width * w * 2;
         break;
       case 2:
-        cachePos = (uint32_t)(_framebuffer + ((HEIGHT - y - h) * _fb_width));
+        cachePos = _framebuffer + ((HEIGHT - y - h) * _fb_width);
         cache_size = _fb_width * h * 2;
         break;
       case 3:
-        cachePos = (uint32_t)(_framebuffer + ((HEIGHT - x - w) * _fb_width));
+        cachePos = _framebuffer + ((HEIGHT - x - w) * _fb_width);
         cache_size = _fb_width * w * 2;
         break;
       default: // case 0:
-        cachePos = (uint32_t)(_framebuffer + (y * _fb_width) + x);
+        cachePos = _framebuffer + (y * _fb_width) + x;
         cache_size = (_fb_width * (h - 1) + w) * 2;
       }
-      Cache_WriteBack_Addr(cachePos, cache_size);
+      _dirty(cachePos, cache_size);
     }
   }
 }
@@ -474,7 +474,7 @@ void Arduino_RGB_Display::draw16bitBeRGBBitmap(int16_t x, int16_t y,
       }
       uint16_t *row = _framebuffer;
       row += y * _fb_width;
-      uint32_t cachePos = (uint32_t)row;
+      uint16_t *cachePos = row;
       row += x;
       uint16_t color;
       for (int j = 0; j < h; j++)
@@ -489,7 +489,7 @@ void Arduino_RGB_Display::draw16bitBeRGBBitmap(int16_t x, int16_t y,
       }
       if (_auto_flush)
       {
-        Cache_WriteBack_Addr(cachePos, _fb_width * h * 2);
+        _dirty(cachePos, _fb_width * h * 2);
       }
     }
   }
@@ -545,7 +545,7 @@ void Arduino_RGB_Display::drawYCbCrBitmap(int16_t x, int16_t y, uint8_t *yData, 
     }
     if (_auto_flush)
     {
-      Cache_WriteBack_Addr((uint32_t)cachePos, _fb_width * h * 2);
+      _dirty(cachePos, _fb_width * h * 2);
     }
   }
 }
@@ -561,6 +561,62 @@ void Arduino_RGB_Display::flush(bool force_flush)
 uint16_t *Arduino_RGB_Display::getFramebuffer()
 {
   return _framebuffer;
+}
+
+void Arduino_RGB_Display::_dirty(const void *ptr, size_t bytes)
+{
+  if (!_auto_flush)
+  {
+    return; // caller drives flush() itself
+  }
+  if (_write_depth == 0)
+  {
+    // Not inside a transaction: preserve the immediate-write contract.
+    Cache_WriteBack_Addr((uint32_t)ptr, bytes);
+    return;
+  }
+  const int32_t lo = (int32_t)((const uint8_t *)ptr - (const uint8_t *)_framebuffer);
+  const int32_t hi = lo + (int32_t)bytes;
+  if (_dirty_begin < 0)
+  {
+    _dirty_begin = lo;
+    _dirty_end = hi;
+  }
+  else
+  {
+    if (lo < _dirty_begin)
+    {
+      _dirty_begin = lo;
+    }
+    if (hi > _dirty_end)
+    {
+      _dirty_end = hi;
+    }
+  }
+}
+
+void Arduino_RGB_Display::startWrite(void)
+{
+  if (_write_depth++ == 0)
+  {
+    _dirty_begin = -1;
+    _dirty_end = -1;
+  }
+}
+
+void Arduino_RGB_Display::endWrite(void)
+{
+  if (_write_depth == 0)
+  {
+    return; // unbalanced call, nothing pending
+  }
+  if ((--_write_depth == 0) && (_dirty_begin >= 0) && (_dirty_end > _dirty_begin))
+  {
+    Cache_WriteBack_Addr((uint32_t)((uint8_t *)_framebuffer + _dirty_begin),
+                          (size_t)(_dirty_end - _dirty_begin));
+    _dirty_begin = -1;
+    _dirty_end = -1;
+  }
 }
 
 #endif // #if defined(ESP32) && (CONFIG_IDF_TARGET_ESP32S3)

--- a/src/display/Arduino_RGB_Display.h
+++ b/src/display/Arduino_RGB_Display.h
@@ -2474,6 +2474,9 @@ public:
     void draw16bitBeRGBBitmap(int16_t x, int16_t y, uint16_t *bitmap, int16_t w, int16_t h) override;
     void flush(bool force_flush = false) override;
 
+    void startWrite(void) override;
+    void endWrite(void) override;
+
     void drawYCbCrBitmap(int16_t x, int16_t y, uint8_t *yData, uint8_t *cbData, uint8_t *crData, int16_t w, int16_t h);
     uint16_t *getFramebuffer();
 
@@ -2491,6 +2494,11 @@ protected:
     uint8_t COL_OFFSET2, ROW_OFFSET2;
     uint8_t _xStart, _yStart;
     uint16_t _fb_width, _fb_height, _fb_max_x, _fb_max_y;
+
+    void _dirty(const void *ptr, size_t bytes);
+    uint16_t _write_depth = 0;
+    int32_t _dirty_begin = -1; // byte offsets into _framebuffer, -1 when empty
+    int32_t _dirty_end = -1;
 
 private:
 };


### PR DESCRIPTION
The RGB framebuffer lives in PSRAM and is read directly by the panel's DMA, so every CPU write has to be pushed out with esp_cache_msync(). Until now each drawing primitive issued that call itself, and writeFastVLineCore() issued one per pixel.

A cache sync costs time on this part, almost independently of the size of the range, so the call count dominates drawing time.

Arduino_GFX already brackets every public drawing call in startWrite()/endWrite(), and the base implementations are empty. This overrides them in Arduino_RGB_Display: the primitives now record the byte range they dirtied instead of flushing it, and endWrite() issues a single esp_cache_msync() over the accumulated range when the outermost transaction closes.

Primitives invoked outside a transaction still sync immediately, so the "visible once the call returns" contract is unchanged, as is the behaviour when auto_flush is disabled and the caller drives flush() itself. Nesting is handled with a depth counter, and an unbalanced endWrite() is ignored rather than flushing a stale range.

Tested on JC8048W550, and added the board into `PDQgraphicstest`
Results:
Before:
<img width="3060" height="2484" alt="before" src="https://github.com/user-attachments/assets/98233b5d-0fe5-4046-a707-c7895d34a7bd" />

After:
<img width="3060" height="2292" alt="after" src="https://github.com/user-attachments/assets/8ab4856c-c050-4a77-a034-153257930125" />

