### PR TITLE
Adds ek79007 init commands into DSI displays

### DIFF
--- a/examples/PDQgraphicstest/Arduino_GFX_dev_device.h
+++ b/examples/PDQgraphicstest/Arduino_GFX_dev_device.h
@@ -2,6 +2,7 @@
 // #define BLOCKCODELAB_ARCADE_LITE
 // #define DLC35010R // or called "Elecrow ESP Terminal with 3.5inch Parallel RGB Capacitive Touch Display (ILI9488)"
 // #define DRAGON_RADAR
+// #define ELECROW_CROWPANEL_ADVANCED_7_P4 // 1024x600 MIPI-DSI, ESP32-P4 (EK79007 panel)
 // #define ESP32_1732S019
 // #define ESP32_2424012
 // #define ESP32_2432S028
@@ -135,6 +136,23 @@ Arduino_ESP32RGBPanel *rgbpanel = new Arduino_ESP32RGBPanel(
 Arduino_RGB_Display *gfx = new Arduino_RGB_Display(
     480 /* width */, 480 /* height */, rgbpanel, 0 /* rotation */, true /* auto_flush */,
     bus, GFX_NOT_DEFINED /* RST */, st7701_type6_init_operations, sizeof(st7701_type6_init_operations));
+
+#elif defined(ELECROW_CROWPANEL_ADVANCED_7_P4)
+#define GFX_DEV_DEVICE ELECROW_CROWPANEL_ADVANCED_7_P4
+#define GFX_BL 31 // LCD_BK_EN: boost converter enable, PWM-dimmable
+#define DEV_DEVICE_INIT()                                                                 \
+    {                                                                                     \
+        pinMode(29 /* LCD_BK_POWER */, OUTPUT);                                           \
+        digitalWrite(29 /* LCD_BK_POWER */, LOW); /* enable boost VIN before GFX_BL does anything */ \
+    }
+#define DSI_PANEL
+Arduino_ESP32DSIPanel *dsipanel = new Arduino_ESP32DSIPanel(
+    10 /* hsync_pulse_width */, 160 /* hsync_back_porch */, 160 /* hsync_front_porch */,
+    1 /* vsync_pulse_width */, 23 /*vsync_back_porch  */, 12 /* vsync_front_porch */,
+    52000000 /* prefer_speed */, 1000 /* lane_bit_rate (Mbps); this panel needs 1000, not the 750 default */);
+Arduino_DSI_Display *gfx = new Arduino_DSI_Display(
+    1024 /* width */, 600 /* height */, dsipanel, 0 /* rotation */, true /* auto_flush */,
+    41 /* RST */, ek79007_init_operations, sizeof(ek79007_init_operations) / sizeof(lcd_init_cmd_t));
 
 #elif defined(ESP32_1732S019)
 #define GFX_DEV_DEVICE ESP32_1732S019

--- a/src/display/Arduino_DSI_Display.h
+++ b/src/display/Arduino_DSI_Display.h
@@ -543,6 +543,22 @@ static const lcd_init_cmd_t hi8561_init_operations[] = {
     //============ Gamma END===========
 };
 
+
+static const lcd_init_cmd_t ek79007_init_operations[] = {
+    //  {cmd, { data }, data_size, delay_ms}
+    // Ported from Espressif's esp_lcd_ek79007 component (vendor_specific_init_default):
+    // https://github.com/espressif/esp-bsp/blob/master/components/lcd/esp_lcd_ek79007/esp_lcd_ek79007.c
+    {0xB2, (uint8_t[]){0x10}, 1, 0}, // PAD control: 2 DSI data lanes
+    {0x80, (uint8_t[]){0x8B}, 1, 0},
+    {0x81, (uint8_t[]){0x78}, 1, 0},
+    {0x82, (uint8_t[]){0x84}, 1, 0},
+    {0x83, (uint8_t[]){0x88}, 1, 0},
+    {0x84, (uint8_t[]){0xA8}, 1, 0},
+    {0x85, (uint8_t[]){0xE3}, 1, 0},
+    {0x86, (uint8_t[]){0x88}, 1, 0},
+    {0x11, (uint8_t[]){0x00}, 0, 120}, // Sleep Out - 120ms delay
+};
+
 #if !defined(CONFIG_SCREEN_PIXEL_FORMAT_RGB565) && !defined(CONFIG_SCREEN_PIXEL_FORMAT_RGB888)
 #define CONFIG_SCREEN_PIXEL_FORMAT_RGB565 1
 #endif


### PR DESCRIPTION
Adds ek79007 display initialization commands, present on [Crowpanel Advance EPS32-P4 7inch](https://github.com/Elecrow-RD/CrowPanel-Advanced-7inch-ESP32-P4-HMI-AI-Display-1024x600-IPS-Touch-Screen/)

Tested and working on [Crowpanel Advance EPS32-P4 7inch](https://www.elecrow.com/crowpanel-advanced-7inch-esp32-p4-hmi-ai-display-1024x600-ips-touch-screen-with-wifi-6-compatible-with-arduino-lvgl-micropython.html)

