### PR TITLE
Arduino_Canvas - check if framebuffer is null before accessing it

### DIFF
--- a/src/canvas/Arduino_Canvas.cpp
+++ b/src/canvas/Arduino_Canvas.cpp
@@ -51,7 +51,7 @@ bool Arduino_Canvas::begin(int32_t speed)
 
 void Arduino_Canvas::writePixelPreclipped(int16_t x, int16_t y, uint16_t color)
 {
-
+  if (!_framebuffer) return;
   uint16_t *fb = _framebuffer;
   switch (_rotation)
   {
@@ -100,6 +100,7 @@ void Arduino_Canvas::writeFastVLineCore(int16_t x, int16_t y,
                                         int16_t h, uint16_t color)
 {
   // log_i("writeFastVLineCore(x: %d, y: %d, h: %d)", x, y, h);
+  if (!_framebuffer) return;
   if (_ordered_in_range(x, 0, MAX_X) && h)
   { // X on screen, nonzero height
     if (h < 0)
@@ -158,6 +159,7 @@ void Arduino_Canvas::writeFastHLineCore(int16_t x, int16_t y,
                                         int16_t w, uint16_t color)
 {
   // log_i("writeFastHLineCore(x: %d, y: %d, w: %d)", x, y, w);
+  if (!_framebuffer) return;
   if (_ordered_in_range(y, 0, MAX_Y) && w)
   { // Y on screen, nonzero width
     if (w < 0)
@@ -195,6 +197,7 @@ void Arduino_Canvas::writeFillRectPreclipped(int16_t x, int16_t y,
                                              int16_t w, int16_t h, uint16_t color)
 {
   // log_i("writeFillRectPreclipped(x: %d, y: %d, w: %d, h: %d)", x, y, w, h);
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     int16_t t = x;
@@ -238,6 +241,7 @@ void Arduino_Canvas::drawIndexedBitmap(
     int16_t x, int16_t y,
     uint8_t *bitmap, uint16_t *color_index, int16_t w, int16_t h, int16_t x_skip)
 {
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     Arduino_GFX::drawIndexedBitmap(x, y, bitmap, color_index, w, h, x_skip);
@@ -311,6 +315,7 @@ void Arduino_Canvas::drawIndexedBitmap(
     int16_t x, int16_t y,
     uint8_t *bitmap, uint16_t *color_index, uint8_t chroma_key, int16_t w, int16_t h, int16_t x_skip)
 {
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     Arduino_GFX::drawIndexedBitmap(x, y, bitmap, color_index, chroma_key, w, h, x_skip);
@@ -409,6 +414,7 @@ void Arduino_Canvas::drawIndexedBitmap(
 void Arduino_Canvas::draw16bitRGBBitmap(int16_t x, int16_t y,
                                         uint16_t *bitmap, int16_t w, int16_t h)
 {
+  if (!_framebuffer) return;
   switch (_rotation)
   {
   case 1:
@@ -429,6 +435,7 @@ void Arduino_Canvas::draw16bitRGBBitmapWithTranColor(
     int16_t x, int16_t y,
     uint16_t *bitmap, uint16_t transparent_color, int16_t w, int16_t h)
 {
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     Arduino_GFX::draw16bitRGBBitmapWithTranColor(x, y, bitmap, transparent_color, w, h);
@@ -516,6 +523,7 @@ void Arduino_Canvas::draw16bitRGBBitmapWithTranColor(
 void Arduino_Canvas::draw16bitBeRGBBitmap(int16_t x, int16_t y,
                                           uint16_t *bitmap, int16_t w, int16_t h)
 {
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     Arduino_GFX::draw16bitBeRGBBitmap(x, y, bitmap, w, h);
@@ -576,7 +584,7 @@ void Arduino_Canvas::draw16bitBeRGBBitmap(int16_t x, int16_t y,
 
 void Arduino_Canvas::flush(bool force_flush)
 {
-  if (_output)
+  if (_output && _framebuffer)
   {
     _output->draw16bitRGBBitmap(_output_x, _output_y, _framebuffer, WIDTH, HEIGHT);
   }
@@ -584,6 +592,7 @@ void Arduino_Canvas::flush(bool force_flush)
 
 void Arduino_Canvas::flushQuad(bool force_flush)
 {
+  if (!_framebuffer) return;
   int16_t y = _output_y;
   uint16_t *row1 = _framebuffer;
   uint16_t *row2 = _framebuffer + WIDTH;
@@ -615,6 +624,7 @@ void Arduino_Canvas::flushQuad(bool force_flush)
 
 void Arduino_Canvas::shade(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t shade_mask)
 {
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     int16_t t = x;

--- a/src/canvas/Arduino_Canvas_3bit.cpp
+++ b/src/canvas/Arduino_Canvas_3bit.cpp
@@ -53,6 +53,7 @@ bool Arduino_Canvas_3bit::begin(int32_t speed)
 
 void Arduino_Canvas_3bit::writePixelPreclipped(int16_t x, int16_t y, uint16_t color)
 {
+  if (!_framebuffer) return;
   int32_t pos = x + (y * _width);
   int32_t idx = pos >> 1;
   uint8_t c = (((color & 0b1000000000000000) ? 0b100 : 0) |
@@ -70,7 +71,7 @@ void Arduino_Canvas_3bit::writePixelPreclipped(int16_t x, int16_t y, uint16_t co
 
 void Arduino_Canvas_3bit::flush(bool force_flush)
 {
-  if (_output)
+  if (_output && _framebuffer)
   {
     _output->draw3bitRGBBitmap(_output_x, _output_y, _framebuffer, _width, _height);
   }

--- a/src/canvas/Arduino_Canvas_Indexed.cpp
+++ b/src/canvas/Arduino_Canvas_Indexed.cpp
@@ -63,6 +63,7 @@ bool Arduino_Canvas_Indexed::begin(int32_t speed)
 
 void Arduino_Canvas_Indexed::writePixelPreclipped(int16_t x, int16_t y, uint16_t color)
 {
+  if (!_framebuffer) return;
   uint8_t idx;
   if (_isDirectUseColorIndex)
   {
@@ -130,6 +131,7 @@ void Arduino_Canvas_Indexed::writeFastVLine(int16_t x, int16_t y,
 void Arduino_Canvas_Indexed::writeFastVLineCore(int16_t x, int16_t y,
                                                 int16_t h, uint8_t idx)
 {
+  if (!_framebuffer) return;
   if (_ordered_in_range(x, 0, MAX_X) && h)
   { // X on screen, nonzero height
     if (h < 0)
@@ -196,6 +198,7 @@ void Arduino_Canvas_Indexed::writeFastHLine(int16_t x, int16_t y,
 void Arduino_Canvas_Indexed::writeFastHLineCore(int16_t x, int16_t y,
                                                 int16_t w, uint8_t idx)
 {
+  if (!_framebuffer) return;
   if (_ordered_in_range(y, 0, MAX_Y) && w)
   { // Y on screen, nonzero width
     if (w < 0)
@@ -232,6 +235,7 @@ void Arduino_Canvas_Indexed::writeFastHLineCore(int16_t x, int16_t y,
 void Arduino_Canvas_Indexed::writeFillRectPreclipped(int16_t x, int16_t y,
                                                      int16_t w, int16_t h, uint16_t color)
 {
+  if (!_framebuffer) return;
   uint8_t idx;
   if (_isDirectUseColorIndex)
   {
@@ -285,6 +289,7 @@ void Arduino_Canvas_Indexed::drawIndexedBitmap(
     int16_t x, int16_t y,
     uint8_t *bitmap, uint16_t *color_index, int16_t w, int16_t h, int16_t x_skip)
 {
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     if (!_isDirectUseColorIndex)
@@ -385,6 +390,7 @@ void Arduino_Canvas_Indexed::drawIndexedBitmap(
     int16_t x, int16_t y,
     uint8_t *bitmap, uint16_t *color_index, uint8_t chroma_key, int16_t w, int16_t h, int16_t x_skip)
 {
+  if (!_framebuffer) return;
   if (_rotation > 0)
   {
     if (!_isDirectUseColorIndex)
@@ -486,7 +492,7 @@ void Arduino_Canvas_Indexed::drawIndexedBitmap(
 
 void Arduino_Canvas_Indexed::flush(bool force_flush)
 {
-  if (_output)
+  if (_output && _framebuffer)
   {
     _output->drawIndexedBitmap(_output_x, _output_y, _framebuffer, _color_index, WIDTH, HEIGHT);
   }
@@ -536,6 +542,7 @@ GFX_INLINE uint16_t Arduino_Canvas_Indexed::get_index_color(uint8_t idx)
 
 void Arduino_Canvas_Indexed::raise_mask_level()
 {
+  if (!_framebuffer) return;
   if ((_current_mask_level + 1) < MAXMASKLEVEL)
   {
     int32_t buffer_size = _width * _height;

--- a/src/canvas/Arduino_Canvas_Mono.cpp
+++ b/src/canvas/Arduino_Canvas_Mono.cpp
@@ -68,6 +68,7 @@ bool Arduino_Canvas_Mono::begin(int32_t speed)
 
 void Arduino_Canvas_Mono::writePixelPreclipped(int16_t x, int16_t y, uint16_t color)
 {
+  if (!_framebuffer) return;
   // change the pixel in the original orientation of the bitmap buffer
   if (_verticalByte)
   {
@@ -102,7 +103,7 @@ void Arduino_Canvas_Mono::writePixelPreclipped(int16_t x, int16_t y, uint16_t co
 
 void Arduino_Canvas_Mono::flush(bool force_flush)
 {
-  if (_output)
+  if (_output && _framebuffer)
   {
     _output->drawBitmap(_output_x, _output_y, _framebuffer, _canvas_width, _canvas_height, RGB565_WHITE, RGB565_BLACK);
   }


### PR DESCRIPTION
If user code tries to draw to canvas buffer before it's allocated it could lead to MCU crash.
Worst case scenario - a bootloop could happen.

Checking for null and refusing any buffer access would prevent crashes and simply discard all draw operations on uninitialized canvas.